### PR TITLE
add link in community packages section to mono-opt packages

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -54,6 +54,7 @@ redirect_from:
           <p>These packages are provided by the community and linked here for your convenience. They are not tested by Xamarin, so use them at your own risk.</p>
           <ul>
             <li><a href="http://monotizen.com/">Tizen</a></li>
+            <li><a href="http://software.opensuse.org/download/package?project=home:tpokorra:mono&package=mono-opt">Mono Packages installed to /opt for CentOS, Fedora, Debian and Ubuntu</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
it might be helpful for people to get their hands on a 3.6.0 build of Mono for their distribution
