### PR TITLE
Added a link to downstream packages

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -37,11 +37,17 @@ redirect_from:
         <div>
           {% include note.html type="alert" message="We're still working on getting these packages released, in the meantime you can use the Mono version that is available from your distribution's package manager." %}
           <p>These packages are built, tested and distributed by Xamarin. Use these if you want to use a stable, official version of Mono.</p>
+        <div>
+        <h4>Linux distribution packages</h4>
+        Mono is packaged in various Linux distributions by third-party maintainers.
+        <div>
           <ul>
-            <li><a href="/docs/getting-started/install/linux/debian/"></a>Debian</li>
-            <li><a href="/docs/getting-started/install/linux/ubuntu/"></a>Ubuntu</li>
+            <li><a href="https://www.archlinux.org/packages/extra/i686/mono/"></a>Arch Linux</li>
             <li><a href="/docs/getting-started/install/linux/centos/"></a>CentOS</li>
-            <li><a href="/docs/getting-started/install/linux/opensuse/"></a>OpenSUSE</li>
+            <li><a href="http://packages.debian.org/mono-complete"></a>Debian</li>
+            <li><a href="http://packages.gentoo.org/package/dev-lang/mono"</a>Gentoo</a>
+            <li><a href="http://software.opensuse.org/package/mono-complete"></a>openSUSE</li>
+            <li><a href="http://packages.ubuntu.com/mono-complete"></a>Ubuntu</li>
           </ul>
         </div>
         <h4>Continuous Integration packages</h4>

--- a/download/index.html
+++ b/download/index.html
@@ -42,12 +42,12 @@ redirect_from:
         Mono is packaged in various Linux distributions by third-party maintainers.
         <div>
           <ul>
-            <li><a href="https://www.archlinux.org/packages/extra/i686/mono/"></a>Arch Linux</li>
+            <li><a href="https://www.archlinux.org/packages/extra/i686/mono/">Arch Linux</a></li>
             <li><a href="/docs/getting-started/install/linux/centos/"></a>CentOS</li>
-            <li><a href="http://packages.debian.org/mono-complete"></a>Debian</li>
-            <li><a href="http://packages.gentoo.org/package/dev-lang/mono"</a>Gentoo</a>
-            <li><a href="http://software.opensuse.org/package/mono-complete"></a>openSUSE</li>
-            <li><a href="http://packages.ubuntu.com/mono-complete"></a>Ubuntu</li>
+            <li><a href="https://packages.debian.org/mono-complete">Debian</a></li>
+            <li><a href="https://packages.gentoo.org/package/dev-lang/mono"</a>Gentoo</li>
+            <li><a href="https://software.opensuse.org/package/mono-complete">openSUSE</a></li>
+            <li><a href="http://packages.ubuntu.com/mono-complete">Ubuntu</a></li>
           </ul>
         </div>
         <h4>Continuous Integration packages</h4>

--- a/download/index.html
+++ b/download/index.html
@@ -37,7 +37,7 @@ redirect_from:
         <div>
           {% include note.html type="alert" message="We're still working on getting these packages released, in the meantime you can use the Mono version that is available from your distribution's package manager." %}
           <p>These packages are built, tested and distributed by Xamarin. Use these if you want to use a stable, official version of Mono.</p>
-        <div>
+        </div>
         <h4>Linux distribution packages</h4>
         Mono is packaged in various Linux distributions by third-party maintainers.
         <div>


### PR DESCRIPTION
To display which version is available where already instead of just the message that @xamarin is working on something on their own which I doubt will be there in time. Added a new section and sorted the distributions alphabetically.
