### PR TITLE
Fixed spelling

### DIFF
--- a/docs/about-mono/languages/index.md
+++ b/docs/about-mono/languages/index.md
@@ -85,7 +85,7 @@ Object Pascal
 
 Their [Delphi Prism](http://www.codegear.com/products/delphi/prism) compiler support Mono out of the box.
 
-LUA
+Lua
 ---
 
 [Lua2Il](http://www.lua.inf.puc-rio.br/luanet/lua2il/) is a compiler that will allow you to run your existing Lua code or reuse the existent expertise you have on Lua in your application and run it with the Mono JIT compiler.

--- a/docs/about-mono/languages/index.md
+++ b/docs/about-mono/languages/index.md
@@ -88,7 +88,7 @@ Their [Delphi Prism](http://www.codegear.com/products/delphi/prism) compiler sup
 Lua
 ---
 
-[Lua2Il](http://www.lua.inf.puc-rio.br/luanet/lua2il/) is a compiler that will allow you to run your existing Lua code or reuse the existent expertise you have on Lua in your application and run it with the Mono JIT compiler.
+[Lua2Il](http://www.lua.inf.puc-rio.br/projects/lua2il.html) is a compiler that will allow you to run your existing Lua code or reuse the existent expertise you have on Lua in your application and run it with the Mono JIT compiler.
 
 Cobra
 -----


### PR DESCRIPTION
> Like most names, it should be written in lower case with an initial capital, that is, "Lua". Please do not write it as "LUA", which is both ugly and confusing, because then it becomes an acronym with different meanings for different people. So, please, write "Lua" right!
