### PR TITLE
Update label.md

### DIFF
--- a/docs/gui/gtksharp/widgets/labels.md
+++ b/docs/gui/gtksharp/widgets/labels.md
@@ -4,7 +4,7 @@ redirect_from:
   - /GtkSharp:_Labels/
 ---
 
-Labels are used a lot in Gtk#, and are relatively simple. Labels emit no events as they do not have an associated X window. If you need to catch events, or do clipping, place it inside a EventBox widget or a Button widget.
+Labels are used a lot in Gtk#, and are relatively simple. Labels emit no events as they do not have an associated X window. If you need to catch events, or do clipping, place it inside an EventBox widget or a Button widget.
 
 [Image:labels.png]
 
@@ -26,7 +26,7 @@ If you want your label underlined, then you can set a pattern on the label:
 label1.Pattern = pattern;
 ```
 
-The pattern argument indicates how the underlining should look. It consists of a string of underscore and space characters. An underscore indicates that the corresponding character in the label should be underlined. For example, the string "`__     __`" would underline the first two characters and eight and ninth characters.
+The pattern argument indicates how the underlining should look. It consists of a string of underscore and space characters. An underscore indicates that the corresponding character in the label should be underlined. For example, the string "`__&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;__`" would underline the first two characters and eight and ninth characters.
 
 If you simply want to have an underlined accelerator ("mnemonic") in your label, you should create the Label with LabelWithMnemonic() or use the TextWithMnemonic property, not the Pattern property.
 


### PR DESCRIPTION
Converted spaces within inline code block to "&nbsp;" so formatting on webpage appears correctly.
