### PR TITLE
Added SUSE Factory repo link

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -65,6 +65,7 @@ redirect_from:
           <p>These packages are provided by the community and linked here for your convenience. They are not tested by Xamarin, so use them at your own risk.</p>
           <ul>
             <li><a href="http://software.opensuse.org/download/package?project=home:tpokorra:mono&package=mono-opt">Mono Packages installed to /opt for CentOS, Fedora, Debian and Ubuntu</a></li>
+            <li><a href="http://software.opensuse.org/download/package?project=Mono:Factory&package=mono-complete">Latest SUSE mono packages, part of the official "Factory" reporitory</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
SUSE Factory updates quickly to the latest mono builds and provides a convenient way to install them; either via adding repository, with 1-click-install, or downloading the rpms.
