### PR TITLE
Use mcs instead of gmcs

### DIFF
--- a/docs/about-mono/supported-platforms/osx.md
+++ b/docs/about-mono/supported-platforms/osx.md
@@ -41,7 +41,7 @@ Using Mono on MacOS X
 
 At this point, you must use Mono from the command line, the usual set of commands that are available on other ports of Mono are available.
 
-To build applications you can use ["gmcs"](/docs/about-mono/languages/csharp/), to run then you can use [mono](/docs/advanced/runtime/).
+To build applications you can use ["mcs"](/docs/about-mono/languages/csharp/), to run then you can use [mono](/docs/advanced/runtime/).
 
 From a Terminal shell, you can try it out:
 


### PR DESCRIPTION
Keep the sample and the surrounding text in sync. Related to ccbd16bed57e5d9df89db779a01555588b2f3619.
