### PR TITLE
Updated downloads page and linux-install docs

### DIFF
--- a/docs/getting-started/install/linux/index.md
+++ b/docs/getting-started/install/linux/index.md
@@ -12,16 +12,14 @@ The Linux community has made Mono available for various distributions, check the
 Installation
 ------------
 
-Regardless of your distribution, you will need the Mono Project public Jenkins GPG signing key, which package managers require:
-
-[http://download.mono-project.com/repo/xamarin.gpg](http://download.mono-project.com/repo/xamarin.gpg)
+Regardless of your distribution, you will need the Mono Project public Jenkins GPG signing key, which package managers require.
 
 ### Debian, Ubuntu, and derivatives
 
 Add the GPG key **in a root shell** with:
 
 ``` bash
-apt-key add xamarin.gpg
+apt-key adv --keyserver pgp.mit.edu --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 ```
 
 Next, add the package repository **in a root shell**:

--- a/download/index.html
+++ b/download/index.html
@@ -39,13 +39,13 @@ redirect_from:
         <div>
           <p>These packages are built, tested and distributed by Xamarin. Use these if you want to use a stable, official version of Mono.</p>
           <h5>Mono packages for Debian, Ubuntu, and derivatives</h5>
-          <p>The Mono package repository is as follows. Please see the installation guide for details on adding it:</p>
+          <p>While the APT package is built against Debian Wheezy, it is compatible with a number of Debian derivatives, including Ubuntu 14.04 LTS. See the <a href="http://www.mono-project.com/docs/getting-started/install/linux/">installation guide</a> for detailed installation instructions across many versions of Debian and Ubuntu.</p>
           <p>Apt repo: <tt>deb http://download.mono-project.com/repo/debian wheezy main</tt></p>
           <h5>Mono packages for Red Hat, SUSE, and derivatives</h5>
           <p>Yum repo: <tt>http://download.mono-project.com/repo/centos/</tt></p>
         </div>
         <h4>Linux distribution packages</h4>
-        <p>Mono is packaged in various Linux distributions by third-party maintainers. Some packages do not ship the latest Mono version, this depends on the distribution/maintainer.</p>
+        <p>Mono is packaged in various Linux distributions by third-party maintainers. Some packages do not ship the latest Mono version; this depends on the distribution/maintainer.</p>
         <div>
           <ul>
             <li><a href="https://www.archlinux.org/packages/extra/i686/mono/">Arch Linux</a></li>

--- a/download/index.html
+++ b/download/index.html
@@ -39,7 +39,7 @@ redirect_from:
         <div>
           <p>These packages are built, tested and distributed by Xamarin. Use these if you want to use a stable, official version of Mono.</p>
           <h5>Mono packages for Debian, Ubuntu, and derivatives</h5>
-          <p>While the APT package is built against Debian Wheezy, it is compatible with a number of Debian derivatives, including Ubuntu 14.04 LTS. See the <a href="http://www.mono-project.com/docs/getting-started/install/linux/">installation guide</a> for detailed installation instructions across many versions of Debian and Ubuntu.</p>
+          <p>While the APT package is built against Debian Wheezy, it is compatible with a number of Debian derivatives, including Ubuntu 14.04 LTS. See the <a href="/docs/getting-started/install/linux/">installation guide</a> for detailed installation instructions across many versions of Debian and Ubuntu.</p>
           <p>Apt repo: <tt>deb http://download.mono-project.com/repo/debian wheezy main</tt></p>
           <h5>Mono packages for Red Hat, SUSE, and derivatives</h5>
           <p>Yum repo: <tt>http://download.mono-project.com/repo/centos/</tt></p>


### PR DESCRIPTION
Updated downloads page and linux-install docs to use the keyserver and to explicitly note that it's not Debian-only.
