### PR TITLE
Explicitly provided --port flag in xsp4 walkthrough

### DIFF
--- a/docs/getting-started/mono-basics.md
+++ b/docs/getting-started/mono-basics.md
@@ -86,7 +86,7 @@ Create a text file with the name hello.aspx and the content:
 Then run the xsp4 command from that directory:
 
 ``` bash
-xsp4
+xsp4 --port 9000
 ```
 
 Use a web browser to contact [http://localhost:9000/hello.aspx](http://localhost:9000/hello.aspx)


### PR DESCRIPTION
This should (hopefully) prevent some novice headaches, given that the default xsp4 port number apparently varies from download to download right now (e.g., Mac OS X MDK .pkg 3.10 still uses port 8080 as default).
