### PR TITLE
Fixed building on OSX quick script

### DIFF
--- a/docs/compiling-mono/linux/index.md
+++ b/docs/compiling-mono/linux/index.md
@@ -65,12 +65,11 @@ If you are on a Debian system (Debian/Ubuntu) and you just want to install Mono 
 #!/bin/bash
 
 PREFIX=$@
-
 if [ -z $PREFIX ]; then
-  PREFIX="/opt/mono/"
+  PREFIX="/usr/local"
 fi
 
-# Ensure you have write permissions to /opt/mono/
+# Ensure you have write permissions to PREFIX
 sudo mkdir $PREFIX
 sudo chown -R `whoami` $PREFIX
 
@@ -85,6 +84,6 @@ make
 make install
 ```
 
-This will by default install mono in /opt/mono/, but you can specify in the first argument of the script the directory of installation. ~/.mono/ might be a nice target as well.
+This will by default install mono in `/usr/local`, but you can specify in the first argument of the script the directory of installation. `/opt/mono` or `~/.mono/` might be a nice target as well.
 
 After installing it successfully, read the notes on [Parallel Mono environments](/docs/compiling-mono/parallel-mono-environments/) on how to use the installed mono instance.

--- a/docs/compiling-mono/mac/index.md
+++ b/docs/compiling-mono/mac/index.md
@@ -29,9 +29,12 @@ PREFIX=/usr/local
 mkdir $PREFIX
 sudo chown -R `whoami` $PREFIX
 
-# Downlaod and build dependencies
+PATH=$PREFIX/bin:$PATH
+
+# Download and build dependencies
 mkdir ~/Build
 cd ~/Build
+curl -O ftp://ftp.gnu.org/gnu/m4/m4-1.4.17.tar.gz
 curl -O ftp://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
 curl -O ftp://ftp.gnu.org/gnu/automake/automake-1.14.tar.gz
 curl -O ftp://ftp.gnu.org/gnu/libtool/libtool-2.4.2.tar.gz
@@ -104,7 +107,7 @@ sudo chown -R `whoami` $PREFIX
 
 PATH=$PREFIX/bin:$PATH
 
-# Downlaod and build dependencies
+# Download and build dependencies
 mkdir ~/Build
 cd ~/Build
 curl -O ftp://ftp.gnu.org/gnu/m4/m4-1.4.17.tar.gz

--- a/docs/compiling-mono/mac/index.md
+++ b/docs/compiling-mono/mac/index.md
@@ -102,9 +102,12 @@ PREFIX=/usr/local
 mkdir $PREFIX
 sudo chown -R `whoami` $PREFIX
 
+PATH=$PREFIX/bin:$PATH
+
 # Downlaod and build dependencies
 mkdir ~/Build
 cd ~/Build
+curl -O ftp://ftp.gnu.org/gnu/m4/m4-1.4.17.tar.gz
 curl -O ftp://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
 curl -O ftp://ftp.gnu.org/gnu/automake/automake-1.14.tar.gz
 curl -O ftp://ftp.gnu.org/gnu/libtool/libtool-2.4.2.tar.gz
@@ -112,7 +115,6 @@ curl -O ftp://ftp.gnu.org/gnu/libtool/libtool-2.4.2.tar.gz
 for i in *.tar.gz; do tar xzvf $i; done
 for i in */configure; do (cd `dirname $i`; ./configure --prefix=$PREFIX && make && make install); done
 
-PATH=$PREFIX/bin:$PATH
 git clone https://github.com/mono/mono.git
 cd mono
 CC='cc -m32' ./autogen.sh --prefix=$PREFIX --disable-nls --build=i386-apple-darwin11.2.0

--- a/docs/compiling-mono/parallel-mono-environments.md
+++ b/docs/compiling-mono/parallel-mono-environments.md
@@ -186,5 +186,5 @@ This may lead you to think that the configure scripts of your programs are buggy
 Common Problems
 ---------------
 
-Sometimes, the wrapper shell scripts for system installed programs to not write out the full path to mono. For example, while in this new environment, you might execute /usr/bin/monodevelop. Sometimes, this results in the **new** mono being used. If this is the case, you should report a bug to the developer. Likewise, even if you specify a path like /opt/mono/bin/monodevelop, the old mono may be used.
+Sometimes, the wrapper shell scripts for system installed programs do not write out the full path to mono. For example, while in this new environment, you might execute /usr/bin/monodevelop. Sometimes, this results in the **new** mono being used. If this is the case, you should report a bug to the developer. Likewise, even if you specify a path like /opt/mono/bin/monodevelop, the old mono may be used.
 


### PR DESCRIPTION
At least on Yosemite I needed to build m4 before I could build autoconf, and to build automake I needed autoconf on the path.

I'm just starting with building mono, so reject these changes if they are wrong.
