### PR TITLE
Actively link websites in 4.0 release note.

### DIFF
--- a/docs/about-mono/releases/4.0.0.md
+++ b/docs/about-mono/releases/4.0.0.md
@@ -78,7 +78,7 @@ incomplete or buggy in Mono and were relatively easy to port to Mono.
 There is much more to be done in this area.  If you are interested in
 tracking those efforts, check the project status:
 
-https://trello.com/b/vRPTMfdz/net-framework-integration-into-mono
+[https://trello.com/b/vRPTMfdz/net-framework-integration-into-mono](https://trello.com/b/vRPTMfdz/net-framework-integration-into-mono)
 
 Mono ships now with a subset of the referencesource that have been
 adjusted to work with Mono's class libraries or have been updated to
@@ -176,7 +176,7 @@ Mono no longer distributes the Npgsql driver.  Developers that need it
 will be better served by using the actively maintained Npgsql driver
 from this site:
 
-https://github.com/npgsql/npgsql
+[https://github.com/npgsql/npgsql](https://github.com/npgsql/npgsql)
 
 ### EntityFramework ###
 


### PR DESCRIPTION
Makes it easier for the reader to just explore
the links by just clicking on them.
