### PR TITLE
Additional package needed

### DIFF
--- a/docs/compiling-mono/linux/index.md
+++ b/docs/compiling-mono/linux/index.md
@@ -22,7 +22,7 @@ On Debian based distribution you should guarantee that some packages are install
 This can be done easily by using *apt-get*:
 
 ```bash
-  $ sudo apt-get install git autoconf libtool automake build-essential mono-devel gettext
+  $ sudo apt-get install git autoconf libtool libtool-bin automake build-essential mono-devel gettext
 ```
 
 Building Mono from a Release Package

--- a/docs/compiling-mono/linux/index.md
+++ b/docs/compiling-mono/linux/index.md
@@ -24,6 +24,7 @@ This can be done easily by using *apt-get*:
 ```bash
   $ sudo apt-get install git autoconf libtool libtool-bin automake build-essential mono-devel gettext
 ```
+Note if you are using Ubuntu 15.04, you also need to install libtool-bin package.
 
 Building Mono from a Release Package
 ------------------------------------

--- a/docs/compiling-mono/linux/index.md
+++ b/docs/compiling-mono/linux/index.md
@@ -22,7 +22,7 @@ On Debian based distribution you should guarantee that some packages are install
 This can be done easily by using *apt-get*:
 
 ```bash
-  $ sudo apt-get install git autoconf libtool libtool-bin automake build-essential mono-devel gettext
+  $ sudo apt-get install git autoconf libtool automake build-essential mono-devel gettext
 ```
 Note if you are using Ubuntu 15.04, you also need to install libtool-bin package.
 


### PR DESCRIPTION
Without libtool-bin autogen will complain (tested on Ubuntu 15.04):
**Error**: You must have `libtool' installed to compile Mono.
