### PR TITLE
As of Mono 4.0, C# 6.0 is supported

### DIFF
--- a/docs/about-mono/compatibility.md
+++ b/docs/about-mono/compatibility.md
@@ -13,10 +13,14 @@ Here is a slightly more detailed view, by .NET framework version:
 
 |<i class="fa fa-check"/>|Implemented|<i class="fa fa-exclamation-triangle"/>|Partially Implemented|<i class="fa fa-ban"/>|Not Implemented|
 
-.NET 4.5
+.NET 4.6
 --------
 
 |<i class="fa fa-check"/>|C# 6.0|
+
+.NET 4.5
+--------
+
 |<i class="fa fa-check"/>|C# 5.0 - async support|
 |<i class="fa fa-check"/>|Async Base Class Library Upgrade|
 |<i class="fa fa-exclamation-triangle"/>|MVC4 *- Partial, no async features supported.*|

--- a/docs/about-mono/compatibility.md
+++ b/docs/about-mono/compatibility.md
@@ -16,6 +16,7 @@ Here is a slightly more detailed view, by .NET framework version:
 .NET 4.5
 --------
 
+|<i class="fa fa-check"/>|C# 6.0|
 |<i class="fa fa-check"/>|C# 5.0 - async support|
 |<i class="fa fa-check"/>|Async Base Class Library Upgrade|
 |<i class="fa fa-exclamation-triangle"/>|MVC4 *- Partial, no async features supported.*|


### PR DESCRIPTION
http://www.mono-project.com/docs/about-mono/releases/4.0.0/ release notes specifies that C# 6.0 has been integrated into Mono. Not sure if we need to remove the C# 5.0 line in compatibility. 
