### PR TITLE
From Mono 4.2 will be supported

### DIFF
--- a/docs/about-mono/compatibility.md
+++ b/docs/about-mono/compatibility.md
@@ -19,6 +19,7 @@ Here is a slightly more detailed view, by .NET framework version:
 |<i class="fa fa-check"/>|C# 5.0 - async support|
 |<i class="fa fa-check"/>|Async Base Class Library Upgrade|
 |<i class="fa fa-exclamation-triangle"/>|MVC4 *- Partial, no async features supported.*|
+|<i class="fa fa-check"/>|MVC5 |
 |<i class="fa fa-ban"/>|ASP.NET 4.5 Async Pipeline *- Needs a parallel processing pipeline with async support, not done.*|
 
 .NET 4.0

--- a/docs/about-mono/compatibility.md
+++ b/docs/about-mono/compatibility.md
@@ -19,7 +19,7 @@ Here is a slightly more detailed view, by .NET framework version:
 |<i class="fa fa-check"/>|C# 5.0 - async support|
 |<i class="fa fa-check"/>|Async Base Class Library Upgrade|
 |<i class="fa fa-exclamation-triangle"/>|MVC4 *- Partial, no async features supported.*|
-|<i class="fa fa-check"/>|MVC5 |
+|<i class="fa fa-exclamation-triangle"/>|MVC5 *- Partial, no async features supported.*|
 |<i class="fa fa-ban"/>|ASP.NET 4.5 Async Pipeline *- Needs a parallel processing pipeline with async support, not done.*|
 
 .NET 4.0


### PR DESCRIPTION
There are a bunch of fixes in Mono 4.2 which deals with MVC 5 support. Currently have MVC 5 running on mono with exception to the fixes I'm waiting for. The only thing that was not working was the lowercase URL's and the append tailing slash function was missing. This should now be fixed.
