### PR TITLE
add links for Fedora and CentOS mono packages

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -50,8 +50,9 @@ redirect_from:
         <div>
           <ul>
             <li><a href="https://www.archlinux.org/packages/extra/i686/mono/">Arch Linux</a></li>
-            <li>CentOS</li>
+            <li><a href="https://apps.fedoraproject.org/packages/mono">CentOS EPEL</a></li>
             <li><a href="https://packages.debian.org/mono-complete">Debian</a></li>
+            <li><a href="https://apps.fedoraproject.org/packages/mono">Fedora</a></li>
             <li><a href="https://packages.gentoo.org/package/dev-lang/mono">Gentoo</a></li>
             <li><a href="https://software.opensuse.org/package/mono-complete">openSUSE</a></li>
             <li><a href="http://packages.ubuntu.com/mono-complete">Ubuntu</a></li>


### PR DESCRIPTION
Adding Fedora as Linux distribution with Mono packages.
There is no mono package in CentOS, but in EPEL.
