### PR TITLE
update the download links of the community packages

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -67,7 +67,9 @@ redirect_from:
         <div>
           <p>These packages are provided by the community and linked here for your convenience. They are not tested by Xamarin, so use them at your own risk.</p>
           <ul>
-            <li><a href="http://software.opensuse.org/download/package?project=home:tpokorra:mono&amp;package=mono-opt">Mono Packages installed to /opt for CentOS, Fedora, Debian and Ubuntu</a></li>
+            <li><a href="http://software.opensuse.org/download/package?project=home:tpokorra:mono&amp;package=mono-opt">Mono Packages installed to /opt for Debian and Ubuntu</a></li>
+            <li><a href="https://copr.fedoraproject.org/coprs/tpokorra/mono-opt/">Mono Packages installed to /opt for CentOS</a></li>
+            <li><a href="https://copr.fedoraproject.org/coprs/tpokorra/mono/">Latest Fedora mono packages for Fedora Rawhide and earlier Fedora versions</a></li>
             <li><a href="http://software.opensuse.org/download/package?project=Mono:Factory&amp;package=mono-complete">Latest SUSE mono packages, part of the official "Factory" repository</a></li>
           </ul>
         </div>


### PR DESCRIPTION
CentOS packages and Fedora packages are not built on OBS anymore, but on Fedora infrastructure
