### PR TITLE
configure `--target=` vs `--host=`

### DIFF
--- a/docs/advanced/mono-llvm.md
+++ b/docs/advanced/mono-llvm.md
@@ -32,7 +32,7 @@ make && make install
 ```
 
 Note that on OSX mono is a 32 bit app, so you need to configure llvm
-with the `--target=i386-apple-darwin10.8.0` flag as by default it will
+with the `--host=i386-apple-darwin10.8.0` flag as by default it will
 build a 64 bit version of the libraries.
 
 Use 'git checkout mono' when compiling against mono HEAD.

--- a/docs/advanced/mono-llvm.md
+++ b/docs/advanced/mono-llvm.md
@@ -32,7 +32,7 @@ make && make install
 ```
 
 Note that on OSX mono is a 32 bit app, so you need to configure llvm
-with the `--host=i386-apple-darwin10.8.0` flag as by default it will
+with the `--build=i386-apple-darwin10.8.0` flag as by default it will
 build a 64 bit version of the libraries.
 
 Use 'git checkout mono' when compiling against mono HEAD.


### PR DESCRIPTION
Correct 32-bit compile as using `--target=` instead of `--host=` will result in target name prefixes added to the llvm binaries, as if you were building a cross-compiled toolchain and thus mono's `configure` process to fail to find `llvm-config`.

```
checking for llvm-config... no
configure: error: llvm-config not found.
```
