### PR TITLE
Some fixes in `Languages' page

### DIFF
--- a/docs/about-mono/languages/index.md
+++ b/docs/about-mono/languages/index.md
@@ -14,14 +14,14 @@ Mono-compatible compilers
 C#
 ---
 
-The main C# compiler of the Mono Project is [**mcs**](/docs/about-mono/languages/csharp/). It covers all the features in C# 3.0 (2.6) and 4.0 (preview), including 3.0 Linq and 4.0 dynamic. As of today, 'gmcs' is the default compiler based on 2.0 runtime profile, and 'dmcs' is for 4.0 runtime profile.
+The main C# compiler of the Mono Project is [**mcs**](/docs/about-mono/languages/csharp/). It covers all the features in C# 3.0 (2.6), 4.0, 5.0 and 6.0 (preview), including 3.0 LINQ, 4.0 dynamic and 5.0 async-await support. As of today, 'gmcs' is the default compiler based on 2.0 runtime profile, and 'dmcs' is for 4.0 runtime profile.
 
 C# is specified in the ISO/IEC 23271:2006 and ECMA 334 standards. Microsoft has [granted access to their patents](http://port25.technet.com/archive/2009/07/06/the-ecma-c-and-cli-standards.aspx) under their [Community Promise](http://www.microsoft.com/interop/cp/default.mspx).
 
 F#
 ---
 
-[F#](http://msdn.microsoft.com/en-us/fsharp/default.aspx) is a hybrid language that brings flavors of functional languages and imperative languages, developed by Microsoft. They release compiler that targets mono in [some releases](http://blogs.msdn.com/b/dsyme/archive/2010/04/12/f-2-0-released-as-part-of-visual-studio-2010.aspx).
+[F#](http://fsharp.org/) is a hybrid language that brings flavors of functional languages and imperative languages, developed by Microsoft. They release compiler that targets mono in [some releases](http://blogs.msdn.com/b/dsyme/archive/2010/04/12/f-2-0-released-as-part-of-visual-studio-2010.aspx).
 
 Java
 ----
@@ -36,7 +36,7 @@ Scala is a modern language primarily targeting Java, and it's ported to .NET as 
 Boo
 ---
 
-[Boo](http://boo.codehaus.org/Home) is a statically-typed language supporting dynamic scripting and meta-programming capabilities (extensible compiler, extensible syntax, macros...) with a syntax similar to Python. For details on the particular language features see the [Boo Language Features](http://boo.codehaus.org/Language+Features) page.
+[Boo](http://boo-language.github.io/) is a statically-typed language supporting dynamic scripting and meta-programming capabilities (extensible compiler, extensible syntax, macros...) with a syntax similar to Python. For details on the particular language features see the [Boo Language Wiki](https://github.com/boo-lang/boo/wiki) page.
 
 Nemerle
 -------
@@ -55,7 +55,7 @@ There are two possible choices here: PythonNet and IronPython.
 
 **PythonNet:** [Brian Lloyd](mailto:brian@No.Spam.zope.com) wrote a bridge to link the Python runtime with the .NET runtime. More information on the PS.NET project can be found [here](http://pythonnet.sourceforge.net/). This uses the real Python engine and provides a bridge between the Python world and the .NET world to interoperate.
 
-**IronPython:** is Jim Hugunin's compiler for Python, it is a complete implementation of Python from scratch that compiles Python code into native CIL. More information is available on [the IronPython site](http://www.codeplex.com/Wiki/View.aspx?ProjectName=IronPython)
+**IronPython:** is Jim Hugunin's compiler for Python, it is a complete implementation of Python from scratch that compiles Python code into native CIL. More information is available on [the IronPython site](http://ironpython.net/)
 
 JavaScript
 ----------
@@ -69,7 +69,7 @@ For more details see [JScript](/archived/jscript)
 Oberon
 ------
 
-Check out [Oberon for .NET](http://www.bluebottle.ethz.ch/oberon.net/) project.
+Check out [Oberon for .NET](http://www.oberon.ethz.ch/archives/systemsarchive/dot_net) project.
 
 PHP
 ---
@@ -83,7 +83,7 @@ Object Pascal
 
 [RemObjects](http://www.remobjects.com) ships an object pascal compiler. Their product is supported in both .NET and Mono.
 
-Their [Delphi Prism](http://www.codegear.com/products/delphi/prism) compiler support Mono out of the box.
+Their [Delphi Prism](http://edn.embarcadero.com/prism) compiler support Mono out of the box.
 
 Lua
 ---
@@ -100,10 +100,10 @@ Cobra combines productivity-boosting features that are otherwise scattered acros
 Other languages
 ---------------
 
--   [Component Pascal](http://plas.fit.qut.edu.au/gpcp/NET.aspx)
--   [Delta Forth](http://www.dataman.ro/dforth)
+-   [Component Pascal](http://www.cfbsoftware.com/gpcp/)
+-   [Delta Forth](http://www.bocan.ro/deltaforthnet)
 -   [DotLisp](http://sourceforge.net/projects/dotlisp)
--   [#Smalltalk](http://www.refactory.com/Software/SharpSmalltalk)
+-   [#Smalltalk](http://www.refactory.com/tools/sharp-smalltalk)
 
 Supporting GCC languages
 ========================
@@ -137,7 +137,7 @@ Ruby
 
 The compiler can be used to statically compile a Ruby source file into a verifiable .NET v2.0 assembly or it can be used to directly execute a Ruby source file (compile, load and execute).
 
-[IronRuby](http://www.wilcob.com/Wilco/IronRuby.aspx) from Wilco Bauwer, includes an interactive Ruby Console and works with Mono.
+[IronRuby](http://ironruby.net/) from Wilco Bauwer, includes an interactive Ruby Console and works with Mono.
 
 ADA
 ---
@@ -151,7 +151,7 @@ Other PHP Efforts
 
 #### Old PHP efforts
 
-[Phalanger](http://www.php-compiler.net/) is a fairly complete PHP to CLI compiler that can even integrate with VS 2003 for console PHP applications.
+[Phalanger](http://www.php-compiler.net/) is a fairly complete PHP to CLI compiler that can even integrate with VS 2010 for console PHP applications.
 
 There is an older effort by Sterling to allow PHP developers to use Mono code, see this [site](http://pecl.php.net/package/mono/).
 
@@ -163,7 +163,7 @@ Languages which are believed to work, but have not had a complete run of all the
 Tachy
 -----
 
-A subset of Scheme language called [Tachy](http://www.kenrawlings.com/pages/Tachy)
+A subset of Scheme language called [Tachy](https://github.com/jeffdik/tachy/tree/master/src)
 
 Mixing with other languages
 ---------------------------
@@ -173,7 +173,6 @@ See [Mixing with other languages](/docs/about-mono/languages/mixing-with-other-l
 .net-language links
 ===================
 
-[DotNetPowered.com](http://www.dotnetpowered.com/languages.aspx) have a list of a lot of .net languages.
+[Brian Ritchie](https://bitbucket.org/brianritchie/wiki/wiki/.NET%20Languages) have a list of a lot of .NET languages.
 
 [Language Comparison](http://bean.wikidot.com/comparecsharpironpythonboo) - A simple comparison of some languages can be used with the Mono platform
-

--- a/docs/about-mono/languages/index.md
+++ b/docs/about-mono/languages/index.md
@@ -14,7 +14,7 @@ Mono-compatible compilers
 C#
 ---
 
-The main C# compiler of the Mono Project is [**mcs**](/docs/about-mono/languages/csharp/). It covers all the features in C# 3.0 (2.6), 4.0, 5.0 and 6.0 (preview), including 3.0 LINQ, 4.0 dynamic and 5.0 async-await support. As of today, 'gmcs' is the default compiler based on 2.0 runtime profile, and 'dmcs' is for 4.0 runtime profile.
+The main C# compiler of the Mono Project is [**mcs**](/docs/about-mono/languages/csharp/). It covers all the features in C# 3.0 (2.6), 4.0, 5.0 and 6.0, including 3.0 LINQ, 4.0 dynamic and 5.0 async-await support. As of today, 'gmcs' is the default compiler based on 2.0 runtime profile, and 'dmcs' is for 4.0 runtime profile.
 
 C# is specified in the ISO/IEC 23271:2006 and ECMA 334 standards. Microsoft has [granted access to their patents](http://port25.technet.com/archive/2009/07/06/the-ecma-c-and-cli-standards.aspx) under their [Community Promise](http://www.microsoft.com/interop/cp/default.mspx).
 

--- a/docs/about-mono/languages/index.md
+++ b/docs/about-mono/languages/index.md
@@ -14,7 +14,7 @@ Mono-compatible compilers
 C#
 ---
 
-The main C# compiler of the Mono Project is [**mcs**](/docs/about-mono/languages/csharp/). It covers all the features in C# 3.0 (2.6), 4.0, 5.0 and 6.0, including 3.0 LINQ, 4.0 dynamic and 5.0 async-await support. As of today, 'gmcs' is the default compiler based on 2.0 runtime profile, and 'dmcs' is for 4.0 runtime profile.
+The main C# compiler of the Mono Project is [**mcs**](/docs/about-mono/languages/csharp/). It covers all the features in C# 3.0 (2.6), 4.0, 5.0 and 6.0, including 3.0 LINQ, 4.0 dynamic and 5.0 async-await support.
 
 C# is specified in the ISO/IEC 23271:2006 and ECMA 334 standards. Microsoft has [granted access to their patents](http://port25.technet.com/archive/2009/07/06/the-ecma-c-and-cli-standards.aspx) under their [Community Promise](http://www.microsoft.com/interop/cp/default.mspx).
 


### PR DESCRIPTION
- Refresh info about MCS language versions.
- F# now have official website. Fixed.
- Boo changed home. There is no separate page with language features now. Fixed.
- IronPython now have official website. Fixed.
- Fixed Oberon.NET link.
- Fixed Delphi Prism link.
- Fixed Component Pascal link.
- Fixed Delta Forth link.
- Fixed #Smalltalk link.
- IronRuby now have official website. Fixed.
- Phalanger now have VS 2010 support, text fixed.
- Tachy have only github page. Link fixed.
- Brian Ritchie moved dotnetpowered to bitbucket. Link fixed.

I can't find any link to Ruby.Net from Queensland University.
