### PR TITLE
Updated Fedora version

### DIFF
--- a/docs/getting-started/install/linux/index.md
+++ b/docs/getting-started/install/linux/index.md
@@ -48,7 +48,7 @@ To enable installation on older Ubuntu releases such as Ubuntu 12.04 and Ubuntu 
 echo "deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main" | sudo tee -a /etc/apt/sources.list.d/mono-xamarin.list
 ```
 
-CentOS 7, Fedora 22 (and later), and derivatives
+CentOS 7, Fedora 19 (and later), and derivatives
 -------------------------------
 
 Add the Mono Project GPG signing key and the package repository **in a root shell** with:

--- a/docs/getting-started/install/linux/index.md
+++ b/docs/getting-started/install/linux/index.md
@@ -48,7 +48,7 @@ To enable installation on older Ubuntu releases such as Ubuntu 12.04 and Ubuntu 
 echo "deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main" | sudo tee -a /etc/apt/sources.list.d/mono-xamarin.list
 ```
 
-CentOS 7, Fedora 19, and derivatives
+CentOS 7, Fedora 22 (and later), and derivatives
 -------------------------------
 
 Add the Mono Project GPG signing key and the package repository **in a root shell** with:

--- a/download/index.html
+++ b/download/index.html
@@ -41,7 +41,7 @@ redirect_from:
           <p>These packages are built, tested and distributed by Xamarin. Use these if you want to use a stable, official and up-to-date version of Mono.</p>
           <ul>
             <li><a href="/docs/getting-started/install/linux/#debian-ubuntu-and-derivatives">Debian, Ubuntu, and derivatives</a></li>
-            <li><a href="/docs/getting-started/install/linux/#centos-7-fedora-19-and-derivatives">CentOS, Fedora, and derivatives</a></li>
+            <li><a href="/docs/getting-started/install/linux/#centos-7-fedora-19-and-later-and-derivatives">CentOS, Fedora, and derivatives</a></li>
             <li><a href="/docs/getting-started/install/linux/#opensuse-and-sles">openSUSE and SLES</a></li>
           </ul>
         </div>


### PR DESCRIPTION
It's a small fix but I think it is important to keep it updated, when I first got to this page I thought it was old so I installed from the distribution package instead. I don't know if Fedora 19 is still supported but Fedora 22 is the latest version that still get updates so there is no reason someone will use something older.
