### PR TITLE
Added the missing SIGCHILD to the list of signals

### DIFF
--- a/docs/advanced/embedding/index.md
+++ b/docs/advanced/embedding/index.md
@@ -599,6 +599,7 @@ Mono consumes a set of signals during execution that your applications will not 
 -   SIGFPE: caught so we can turn that into an exception
 -   SIGQUIT, SIGKILL to produce ExecutionEngineException.
 -   SIGSEGV: to produce NullReferenceExceptions
+-   SIGCHLD: to track the life-cycle of processes (notably System.Diagnostics.Process)
 
 One signal picked at startup time between SIGRTMIN and SIGRTMAX. The signal is picked up by finding a signal in that range which is set to SIG_DFL.
 


### PR DESCRIPTION
mono also uses the SIGCHILD to find out when a sub process has terminated before calling waitpid.
Ignoring this handler can lead to deadlocks during C# calls or <defunct> zombie processes as waitpid will never be called.

https://github.com/mono/mono/blob/master/mono/io-layer/processes.c#L2717
