### PR TITLE
Remove broken image reference of: buttons.png

### DIFF
--- a/docs/gui/gtksharp/widgets/buttons.md
+++ b/docs/gui/gtksharp/widgets/buttons.md
@@ -24,8 +24,6 @@ After creating a button using its argument-less constructor, it's then up to you
 
 Here's an example of creating a button with a image and a label in it. I've broken up the code to create a box from the rest so you can use it in your programs. There are further examples of using images later in the tutorial.
 
-[Image:buttons.png]
-
 ``` csharp
 // /samples/tutorial/buttons/buttons.cs - Gtk# Tutorial example
 //


### PR DESCRIPTION
Proposing removal of broken image reference `[Image:buttons.png]`, which doesn't appear to be GitHub flavored markdown.

This image asset cannot be found within this repository; nor, is present within the [earliest web archive of this page](https://web.archive.org/web/20051230200243/http://www.mono-project.com/GtkSharp:_Buttons).  Only artifacts that can be located are perhaps from the former CVS repository.
