### PR TITLE
Packages list actualised

### DIFF
--- a/docs/compiling-mono/windows/index.md
+++ b/docs/compiling-mono/windows/index.md
@@ -9,7 +9,7 @@ There are two ways of building Mono on Windows, both do require a Cygwin setup w
 Run the following command in cmd.exe to install the required packages:
 
 ``` shell
-setup-x86.exe --root "C:\cygwin" --quiet-mode --packages autoconf,automake,bison,gcc-core,gcc-g++,mingw-runtime,mingw-binutils,mingw-gcc-core,mingw-gcc-g++,mingw-pthreads,mingw-w32api,libtool,make,python,gettext-devel,gettext,intltool,libiconv,pkg-config,git,curl,libxslt
+setup-x86.exe --root "C:\cygwin" --quiet-mode --packages autoconf,automake,bison,gcc-core,gcc-g++,mingw64-i686-runtime,mingw64-i686-binutils,mingw64-i686-gcc-core,mingw64-i686-gcc-g++,mingw64-i686-pthreads,w32api-headers,libtool,make,python,gettext-devel,gettext,intltool,libiconv,pkg-config,git,curl,libxslt
 ```
 
 At this point, you can either do a [Visual Studio build](/docs/compiling-mono/windows/compiling-with-visualstudio/) or you can continue reading the instructions for a Cygwin build.


### PR DESCRIPTION
The following packages are not anymore in repository and/or changed their names:

mingw-runtime,mingw-binutils,mingw-gcc-core,mingw-gcc-g++,mingw-pthreads,mingw-w32api

Thus compilation is impossible if you try to follow official documentation from the website.
New versions proposed for update:

mingw64-i686-runtime, mingw64-i686-binutils, mingw64-i686-gcc-core, mingw64-i686-gcc-g++, mingw64-i686-pthreads, w32api-headers

that will preserve x32 versions of the packages
