### PR TITLE
Add link to Slackware packages

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -51,7 +51,6 @@ redirect_from:
             <li><a href="https://packages.gentoo.org/package/dev-lang/mono">Gentoo</a></li>
             <li><a href="https://software.opensuse.org/package/mono-complete">openSUSE</a></li>
             <li><a href="http://packages.ubuntu.com/mono-complete">Ubuntu</a></li>
-            <li><a href="http://sotirov-bg.net/slackpack/search.cgi?q&equals;mono">Slackware</a></li>
           </ul>
         </div>
         <h4>Continuous Integration packages</h4>
@@ -67,6 +66,7 @@ redirect_from:
             <li><a href="https://copr.fedoraproject.org/coprs/tpokorra/mono-opt/">Mono Packages installed to /opt for CentOS</a></li>
             <li><a href="https://copr.fedoraproject.org/coprs/tpokorra/mono/">Latest Fedora mono packages for Fedora Rawhide and earlier Fedora versions</a></li>
             <li><a href="http://software.opensuse.org/download/package?project=Mono:Factory&amp;package=mono-complete">Latest SUSE mono packages, part of the official "Factory" repository</a></li>
+            <li><a href="http://sotirov-bg.net/slackpack/search.cgi?q=mono">Latest Slackware mono packages from SlackPack repository</a></li>
           </ul>
         </div>
       </div>

--- a/download/index.html
+++ b/download/index.html
@@ -51,6 +51,7 @@ redirect_from:
             <li><a href="https://packages.gentoo.org/package/dev-lang/mono">Gentoo</a></li>
             <li><a href="https://software.opensuse.org/package/mono-complete">openSUSE</a></li>
             <li><a href="http://packages.ubuntu.com/mono-complete">Ubuntu</a></li>
+            <li><a href="http://sotirov-bg.net/slackpack/search.cgi?q&equals;mono">Slackware</a></li>
           </ul>
         </div>
         <h4>Continuous Integration packages</h4>


### PR DESCRIPTION
I'm providing third party packages of Mono for [Slackware Linux](http://slackware/) (both 32 and 64 bit) from my site [SlackPack](http://sotirov-bg.net/slackpack/), so I hope they're useful for anyone trying to use Mono on this distribution.
