### PR TITLE
Change some http links to https, especially download links

### DIFF
--- a/_data/alpharelease.yml
+++ b/_data/alpharelease.yml
@@ -1,5 +1,5 @@
 version: 4.6 Service Release 0.1 (4.6.1.5)
-mono_mac_url: http://download.mono-project.com/archive/4.6.1/macos-10-universal/MonoFramework-MDK-4.6.1.5.macos10.xamarin.universal.pkg
-mono_windows_url: http://download.mono-project.com/archive/4.6.1/windows-installer/mono-4.6.1.5-gtksharp-2.12.38-win32-0.msi
-mono_windows64_url: http://download.mono-project.com/archive/4.6.1/windows-installer/mono-4.6.1.5-x64-0.msi
-gtksharp_windows_url: http://download.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.38.msi
+mono_mac_url: https://download.mono-project.com/archive/4.6.1/macos-10-universal/MonoFramework-MDK-4.6.1.5.macos10.xamarin.universal.pkg
+mono_windows_url: https://download.mono-project.com/archive/4.6.1/windows-installer/mono-4.6.1.5-gtksharp-2.12.38-win32-0.msi
+mono_windows64_url: https://download.mono-project.com/archive/4.6.1/windows-installer/mono-4.6.1.5-x64-0.msi
+gtksharp_windows_url: https://download.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.38.msi

--- a/_data/betarelease.yml
+++ b/_data/betarelease.yml
@@ -1,5 +1,5 @@
 version: 4.6 Service Release 0.1 (4.6.1.5)
-mono_mac_url: http://download.mono-project.com/archive/4.6.1/macos-10-universal/MonoFramework-MDK-4.6.1.5.macos10.xamarin.universal.pkg
-mono_windows_url: http://download.mono-project.com/archive/4.6.1/windows-installer/mono-4.6.1.5-gtksharp-2.12.38-win32-0.msi
-mono_windows64_url: http://download.mono-project.com/archive/4.6.1/windows-installer/mono-4.6.1.5-x64-0.msi
-gtksharp_windows_url: http://download.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.38.msi
+mono_mac_url: https://download.mono-project.com/archive/4.6.1/macos-10-universal/MonoFramework-MDK-4.6.1.5.macos10.xamarin.universal.pkg
+mono_windows_url: https://download.mono-project.com/archive/4.6.1/windows-installer/mono-4.6.1.5-gtksharp-2.12.38-win32-0.msi
+mono_windows64_url: https://download.mono-project.com/archive/4.6.1/windows-installer/mono-4.6.1.5-x64-0.msi
+gtksharp_windows_url: https://download.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.38.msi

--- a/_data/latestrelease.yml
+++ b/_data/latestrelease.yml
@@ -1,5 +1,5 @@
 version: 4.6 Service Release 0.1 (4.6.1.5)
-mono_mac_url: http://download.mono-project.com/archive/4.6.1/macos-10-universal/MonoFramework-MDK-4.6.1.5.macos10.xamarin.universal.pkg
-mono_windows_url: http://download.mono-project.com/archive/4.6.1/windows-installer/mono-4.6.1.5-gtksharp-2.12.38-win32-0.msi
-mono_windows64_url: http://download.mono-project.com/archive/4.6.1/windows-installer/mono-4.6.1.5-x64-0.msi
-gtksharp_windows_url: http://download.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.38.msi
+mono_mac_url: https://download.mono-project.com/archive/4.6.1/macos-10-universal/MonoFramework-MDK-4.6.1.5.macos10.xamarin.universal.pkg
+mono_windows_url: https://download.mono-project.com/archive/4.6.1/windows-installer/mono-4.6.1.5-gtksharp-2.12.38-win32-0.msi
+mono_windows64_url: https://download.mono-project.com/archive/4.6.1/windows-installer/mono-4.6.1.5-x64-0.msi
+gtksharp_windows_url: https://download.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.38.msi

--- a/_posts/2015-03-07-mono-tls-vulnerability.md
+++ b/_posts/2015-03-07-mono-tls-vulnerability.md
@@ -29,7 +29,7 @@ pre-3.4](https://gist.github.com/directhex/f8c6e67f551d8a608154)
 should work for these users.
 
 Alternatively, this is fixed in Mono 3.12.1 and higher:
-[mono-3.12.1.tar.bz2](http://download.mono-project.com/sources/mono/mono-3.12.1.tar.bz2)
+[mono-3.12.1.tar.bz2](https://download.mono-project.com/sources/mono/mono-3.12.1.tar.bz2)
 
 Mono's github repository contains the bug fix for all supported branches
 (master, mono-4.0.0-branch, mono-3.12.0-branch, mono-3.10.0-branch).

--- a/_posts/2015-05-04-mono-4-0-is-out.md
+++ b/_posts/2015-05-04-mono-4-0-is-out.md
@@ -10,7 +10,7 @@ Mono 4.0 is out.
 Check out our [release notes](http://www.mono-project.com/docs/about-mono/releases/4.0.0/)
 for details about what is new on Mono 4.0.
 
-This is the first Mono release that contains code from [Microsoft's open sourced .NET code](http://github.com/mono/referencesource).
+This is the first Mono release that contains code from [Microsoft's open sourced .NET code](https://github.com/mono/referencesource).
 We are only getting started with this work.   We are swiftly [moving ahead](https://trello.com/b/vRPTMfdz/net-framework-integration-into-mono) in mono/master much more code that is being replaced and ported.
 
 This version also is the first one to ship with C# 6.0 enabled by default.   Learn all about C# 6.0 in only eight minutes on [this presentation](http://channel9.msdn.com/Series/ConnectOn-Demand/211)

--- a/archived/accessibility.md
+++ b/archived/accessibility.md
@@ -133,8 +133,8 @@ Related Material
 
 ### Mono Winforms
 
--   [WinForms](http://github.com/mono/winforms) code in Mono's mcs project (ViewVC)
--   [UIAutomationWinforms](http://github.com/mono/uia2atk) project for winforms providers (ViewVC)
+-   [WinForms](https://github.com/mono/winforms) code in Mono's mcs project (ViewVC)
+-   [UIAutomationWinforms](https://github.com/mono/uia2atk) project for winforms providers (ViewVC)
 
 ### Other Organizations
 

--- a/archived/accessibility_installing_20_from_source.md
+++ b/archived/accessibility_installing_20_from_source.md
@@ -50,8 +50,8 @@ Prerequisites
 -   atk
 -   nunit \>= 2.4.7 (if building tests)
 -   at-spi2 \>= 0.1.7
-    -   [http://download.gnome.org/sources/at-spi2-core/0.1/](http://download.gnome.org/sources/at-spi2-core/0.1/)
-    -   [http://download.gnome.org/sources/at-spi2-atk/0.1/](http://download.gnome.org/sources/at-spi2-atk/0.1/)
+    -   [https://download.gnome.org/sources/at-spi2-core/0.1/](https://download.gnome.org/sources/at-spi2-core/0.1/)
+    -   [https://download.gnome.org/sources/at-spi2-atk/0.1/](https://download.gnome.org/sources/at-spi2-atk/0.1/)
 
 Getting the Source
 ------------------

--- a/archived/accessibility_installing_21_from_source.md
+++ b/archived/accessibility_installing_21_from_source.md
@@ -50,8 +50,8 @@ Prerequisites
 -   atk
 -   nunit \>= 2.4.7 (if building tests)
 -   at-spi2 \>= 0.3.90
-    -   [http://download.gnome.org/sources/at-spi2-core/0.3/](http://download.gnome.org/sources/at-spi2-core/0.3/)
-    -   [http://download.gnome.org/sources/at-spi2-atk/0.3/](http://download.gnome.org/sources/at-spi2-atk/0.3/)
+    -   [https://download.gnome.org/sources/at-spi2-core/0.3/](https://download.gnome.org/sources/at-spi2-core/0.3/)
+    -   [https://download.gnome.org/sources/at-spi2-atk/0.3/](https://download.gnome.org/sources/at-spi2-atk/0.3/)
 
 Getting the Source
 ------------------

--- a/archived/accessibility_moonlight.md
+++ b/archived/accessibility_moonlight.md
@@ -61,8 +61,8 @@ For Developers
 
 In order to enable Moonlight Accessibility in Firefox you have to apply a patch, this patch depends on the version of Firefox. We have two patches, one for *mozilla-1.9.2* and one for *mozilla-central*. Make sure you are using compatible revisions and patches otherwise Moonlight Accessibility will not compile nor work.
 
--   *mozilla-1.9.2* is compatible with [Moon 2.0 (branch)](http://github.com/mono/moon/tree/moon/moon-2-0) and MoonAtkBridge (trunk).
--   *mozilla-central* is compatible with [Moon (master)](http://github.com/mono/moon) and MoonAtkBridge+patch (trunk).
+-   *mozilla-1.9.2* is compatible with [Moon 2.0 (branch)](https://github.com/mono/moon/tree/moon/moon-2-0) and MoonAtkBridge (trunk).
+-   *mozilla-central* is compatible with [Moon (master)](https://github.com/mono/moon) and MoonAtkBridge+patch (trunk).
 
 Before building Firefox you will need to install the following libraries:
 
@@ -90,7 +90,7 @@ Notice latest patch is tracked in [Mozilla Bug #480317](https://bugzilla.mozilla
 ### Building Firefox with Plugin Accessibility (mozilla-1.9.2)
 
 -   [Check out](https://developer.mozilla.org/en/Mozilla_Source_Code_(Mercurial)) Firefox from *mozilla-1.9.2 (Firefox 3.6)*
--   Apply the latest plugin accessibility patch from [uia2atk/MoonAtkBridge](http://github.com/mono/uia2atk/blob/master/MoonAtkBridge/patches/ff-plugin-a11y.patch)
+-   Apply the latest plugin accessibility patch from [uia2atk/MoonAtkBridge](https://github.com/mono/uia2atk/blob/master/MoonAtkBridge/patches/ff-plugin-a11y.patch)
 -   Move your .mozconfig to your checkout folder and build for the first time:
 
 <!-- -->
@@ -102,7 +102,7 @@ Notice latest patch is tracked in [Mozilla Bug #480317](https://bugzilla.mozilla
 ### Building Firefox with Plugin Accessibility (mozilla-central)
 
 -   [Check out](https://developer.mozilla.org/en/Mozilla_Source_Code_(Mercurial)) Firefox from *mozilla-central (Firefox 4.0)*
--   Apply the latest plugin accessibility patch from [uia2atk/MoonAtkBridge](http://github.com/mono/uia2atk/blob/master/MoonAtkBridge/patches/mozilla-central/ff-plugin-a11y.patch)
+-   Apply the latest plugin accessibility patch from [uia2atk/MoonAtkBridge](https://github.com/mono/uia2atk/blob/master/MoonAtkBridge/patches/mozilla-central/ff-plugin-a11y.patch)
 -   Move your .mozconfig to your checkout folder and build for the first time:
 
 <!-- -->
@@ -290,7 +290,7 @@ The most important thing to notice is **Plugin Installer (.xpi): yes**.
 
     git clone git://github.com/mono/moon.git
 
--   Open the README file in moon and look for the section called: **Requirements**, in that section you will notice the revisions required to build moonlight, for example *[moon 79a21b](http://github.com/mono/moon/commit/79a21bf3713bef8832a5c8c04f3c3e4ca84295d6)*:
+-   Open the README file in moon and look for the section called: **Requirements**, in that section you will notice the revisions required to build moonlight, for example *[moon 79a21b](https://github.com/mono/moon/commit/79a21bf3713bef8832a5c8c04f3c3e4ca84295d6)*:
 
 <!-- -->
 

--- a/archived/accessibility_testing_howto.md
+++ b/archived/accessibility_testing_howto.md
@@ -126,7 +126,7 @@ This tutorial will *not* have in-depth explanations about the Strongwind-specifi
 -   [GNOME](http://www.gnome.org)
 -   [Python](http://www.python.org) (\>=2.5, \<3.0)
 -   Enable "Assistive Technologies" from the GNOME Control Center
--   pyatspi (packaged with [AT-SPI](http://ftp.gnome.org/pub/GNOME/sources/at-spi))
+-   pyatspi (packaged with [AT-SPI](https://ftp.gnome.org/pub/GNOME/sources/at-spi))
 -   [Accerciser](http://live.gnome.org/Accerciser) (1.4.0 or later)
 -   [Strongwind](http://medsphere.org/projects/strongwind) (installing from SVN trunk is highly recommended)
 -   [IronPython](http://www.codeplex.com/Wiki/View.aspx?ProjectName=IronPython) (the package name in openSUSE is IPCE). Our sample applications are written in IronPython, so it must be installed for them to run successfully.
@@ -523,9 +523,9 @@ It is recommended that you use a Virtual Machine (VM) for testing. You should ta
 -   [GNOME](http://www.gnome.org)
 -   [Python](http://www.python.org)
 -   Enable "Assistive Technologies" from the GNOME Control Center
--   pyatspi (packaged with [AT-SPI](http://ftp.gnome.org/pub/GNOME/sources/at-spi))
+-   pyatspi (packaged with [AT-SPI](https://ftp.gnome.org/pub/GNOME/sources/at-spi))
 -   [uia2atk code](/archived/accessibility_getting_started_with_development/#getting-the-code). The QA-related code is in the test directory. There are short README files in the test directory and each of its subdirectories. Read these README files if you are confused about the files and directories you are seeing. The code can also be checked out anonymously (using subversion) by running *svn co [svn://anonsvn.mono-project.com/source/trunk/uia2atk](svn://anonsvn.mono-project.com/source/trunk/uia2atk)*.
--   Install intltool \>=0.40.0 ([http://ftp.acc.umu.se/pub/GNOME/sources/intltool/0.40/intltool-0.40.3.tar.gz](http://ftp.acc.umu.se/pub/GNOME/sources/intltool/0.40/intltool-0.40.3.tar.gz)).
+-   Install intltool \>=0.40.0 ([https://ftp.gnome.org/pub/GNOME/sources/intltool/0.40/intltool-0.40.3.tar.gz](https://ftp.gnome.org/pub/GNOME/sources/intltool/0.40/intltool-0.40.3.tar.gz)).
 -   Install Orca revision 4277 (version 2.24.00???) from source (svn co -r 4277 [http://svn.gnome.org/svn/orca/trunk](http://svn.gnome.org/svn/orca/trunk) orca) so you can follow along with the examples. We must check out the code fron svn because the test code is in the svn trunk but it not in the tarballs or source packages. Additionally, we want to make sure we use the same revision on all test machines so we do not get varying test results.
 -   Set *orca.debug.debugLevel = orca.debug.LEVEL_INFO* in your \~/.orca/user-settings.py file. This is explained in [Writing Orca Tests](http://live.gnome.org/Orca/RegressionTesting/WritingTests), which is mentioned below and should be read prior to writing tests for Orca.
 -   Install [Accerciser](http://live.gnome.org/Accerciser) from source. [Here](http://bgmerrell.blogspot.com/2008/07/buildling-accerciser-from-source-on.html) are some instructions to do this easily.

--- a/archived/bindingmoko.md
+++ b/archived/bindingmoko.md
@@ -97,5 +97,5 @@ Parser warnings can sometimes be worked around by patching the source files to m
 
 Compile errors can occur because of name conflicts in the bound api. Often, C methods with collide with signal names, for example. These sorts of issues can be worked around using gapi2-fixup and a metadata rule file. The fixup tool is a highly flexible way to markup the api.xml file. More information on metadata rules is available on the [GAPI](/GAPI) reference wiki page.
 
-The sample files for this example are [available for download](http://downloads.sourceforge.net/gtk-sharp/moko-sharp-0.1.tar.gz).
+The sample files for this example are [available for download](https://downloads.sourceforge.net/gtk-sharp/moko-sharp-0.1.tar.gz).
 

--- a/archived/eglib.md
+++ b/archived/eglib.md
@@ -8,9 +8,9 @@ redirect_from:
 Eglib
 =====
 
-eglib is an embedded glib library available in the [mono repo](http://github.com/mono/mono/tree/master/eglib), which is a drop in replacement for glib for systems which don't have glib (or for users that prefer a reduced/slimmed version).
+eglib is an embedded glib library available in the [mono repo](https://github.com/mono/mono/tree/master/eglib), which is a drop in replacement for glib for systems which don't have glib (or for users that prefer a reduced/slimmed version).
 
 eglib is not present in tarballs before version 2.7.
 
-For more information, read the [README](http://github.com/mono/mono/blob/master/eglib/README).
+For more information, read the [README](https://github.com/mono/mono/blob/master/eglib/README).
 

--- a/archived/gtkglarea.md
+++ b/archived/gtkglarea.md
@@ -59,5 +59,5 @@ Projects using this package
 Download
 --------
 
-[http://ftp.gnome.org/pub/GNOME/sources/gtkglarea/2.0/](http://ftp.gnome.org/pub/GNOME/sources/gtkglarea/2.0/)
+[https://ftp.gnome.org/pub/GNOME/sources/gtkglarea/2.0/](https://ftp.gnome.org/pub/GNOME/sources/gtkglarea/2.0/)
 

--- a/archived/gtkglareasharpinstallation.md
+++ b/archived/gtkglareasharpinstallation.md
@@ -18,7 +18,7 @@ GtkGlAreaSharp:Installation
 
 // Download gtkglarea
 
-    wget ftp://ftp.gnome.org/mirror/gnome.org/sources/gtkglarea/1.99/gtkglarea-1.99.0.tar.bz2
+    wget https://ftp.gnome.org/mirror/gnome.org/sources/gtkglarea/1.99/gtkglarea-1.99.0.tar.bz2
 
 // Check out gtkglarea-sharp from svn
 

--- a/archived/gtksharper.md
+++ b/archived/gtksharper.md
@@ -58,11 +58,11 @@ Our current stable release targets the GNOME 2.20 release.
 
 Current Source Releases:
 
--   [gtk-sharp](http://ftp.gnome.org/pub/gnome/sources/gtk-sharp/2.12/gtk-sharp-2.12.0.tar.gz)
--   [gnome-sharp](http://ftp.gnome.org/pub/gnome/sources/gnome-sharp/2.20/gnome-sharp-2.20.0.tar.gz)
--   [gnome-desktop-sharp](http://ftp.gnome.org/pub/gnome/sources/gnome-desktop-sharp/2.20/gnome-desktop-sharp-2.20.1.tar.gz)
+-   [gtk-sharp](https://ftp.gnome.org/pub/gnome/sources/gtk-sharp/2.12/gtk-sharp-2.12.0.tar.gz)
+-   [gnome-sharp](https://ftp.gnome.org/pub/gnome/sources/gnome-sharp/2.20/gnome-sharp-2.20.0.tar.gz)
+-   [gnome-desktop-sharp](https://ftp.gnome.org/pub/gnome/sources/gnome-desktop-sharp/2.20/gnome-desktop-sharp-2.20.1.tar.gz)
 
 [Packages and installers](/Downloads)
 
-Sources for older releases can be downloaded from [GNOME FTP](http://ftp.gnome.org/pub/gnome/sources/gtk-sharp).
+Sources for older releases can be downloaded from [GNOME FTP](https://ftp.gnome.org/pub/gnome/sources/gtk-sharp).
 

--- a/archived/i18ngettext.md
+++ b/archived/i18ngettext.md
@@ -47,7 +47,7 @@ All the examples were tested using mono 1.1.6, Gtk# 1.9.3 and Gettext# 0.14.
 
 #### Installation
 
-You can download the current version from [here](http://ftp.gnu.org/gnu/gettext/gettext-0.14.tar.gz). The older version can the downloaded from [this](http://ftp.gnu.org/gnu/gettext/) site. Older versions of Gettext doesn't support C#, so older versions doesn't work.
+You can download the current version from [here](https://ftp.gnu.org/gnu/gettext/gettext-0.14.tar.gz). The older version can the downloaded from [this](https://ftp.gnu.org/gnu/gettext/) site. Older versions of Gettext doesn't support C#, so older versions doesn't work.
 
 After downloading the package you need to uncompress it.
 

--- a/archived/monozeroconf.md
+++ b/archived/monozeroconf.md
@@ -95,8 +95,8 @@ Packages for many Linux distributions are available through the Mono project in 
 -   [Fedora 8](http://download.opensuse.org/repositories/Mono/Fedora_8)
 -   [Fedora 7](http://download.opensuse.org/repositories/Mono/Fedora_7)
 -   [Fedora Core 6](http://download.opensuse.org/repositories/Mono/Fedora_Extras_6)
--   [Debian/Testing](http://packages.debian.org/testing/libmono-zeroconf1.0-cil)
--   [Debian/Unstable](http://packages.debian.org/unstable/libmono-zeroconf1.0-cil)
+-   [Debian/Testing](https://packages.debian.org/testing/libmono-zeroconf1.0-cil)
+-   [Debian/Unstable](https://packages.debian.org/unstable/libmono-zeroconf1.0-cil)
 
 ### Git
 

--- a/archived/moonlightdesktop.md
+++ b/archived/moonlightdesktop.md
@@ -181,7 +181,7 @@ Building Moonlight for the Desktop
 Building Moonlight
 ------------------
 
-Please carefully read the [README](http://github.com/mono/moon/raw/master/README) file on github for the latest Moonlight build instructions.
+Please carefully read the [README](https://github.com/mono/moon/raw/master/README) file on github for the latest Moonlight build instructions.
 
 Make sure that you pass the flag: --enable-desktop-support to configure, to ensure that the Moonlight Desktop assemblies are compiled.
 

--- a/archived/systemxamlhacking.md
+++ b/archived/systemxamlhacking.md
@@ -44,7 +44,7 @@ Scope
 
 We have System.Xaml.dll which was introduced in the .NET 4.0 API.
 
-Note that there is another effort for managed XAML parser in [Moonlight](/Moonlight) land (in [Mono.Xaml namespace in System.Windows.dll](http://github.com/mono/moon/tree/master/class/System.Windows/Mono.Xaml/) in its own API.
+Note that there is another effort for managed XAML parser in [Moonlight](/Moonlight) land (in [Mono.Xaml namespace in System.Windows.dll](https://github.com/mono/moon/tree/master/class/System.Windows/Mono.Xaml/) in its own API.
 
 System.Xaml.dll in .NET 4 is used by WF4 and WPF, but we don't have them yet. Hence supporting WF4 or WPF XAML by this library is out of scope.
 

--- a/archived/thirdpartypackages.md
+++ b/archived/thirdpartypackages.md
@@ -50,7 +50,7 @@ Debian
 
 Binary packages for Debian are available for Debian/Unstable and Debian/Testing:
 
-[http://packages.debian.org/unstable/interpreters/mono](http://packages.debian.org/unstable/interpreters/mono)
+[https://packages.debian.org/unstable/interpreters/mono](https://packages.debian.org/unstable/interpreters/mono)
 
 Backports for Debian/Stable (Sarge):
 

--- a/community/contributing/coding-guidelines.md
+++ b/community/contributing/coding-guidelines.md
@@ -827,7 +827,7 @@ Backporting Changes
 
 If you want to backport an interesting change to a branch, you can follow these steps.
 
-Let us say that you want to backport this change: [http://github.com/mono/mono/commit/778694e1b85416a3abfdac4952dd85c8384e1cf8](http://github.com/mono/mono/commit/778694e1b85416a3abfdac4952dd85c8384e1cf8) into the remote branch monotouch-2-0.
+Let us say that you want to backport this change: [https://github.com/mono/mono/commit/778694e1b85416a3abfdac4952dd85c8384e1cf8](https://github.com/mono/mono/commit/778694e1b85416a3abfdac4952dd85c8384e1cf8) into the remote branch monotouch-2-0.
 
 To do this, first you would create a local branch called "monotouch-2-0" that tracks the remote monotouch-2-0 branch:
 
@@ -874,7 +874,7 @@ git push
 ChangeLogs
 ----------
 
-**Update**: ChangeLogs are no longer manually updated, instead just use the ChangeLog message on your commit. At release time, a script merges the commit messages into the proper ChangeLogs that are distributed. For a few examples on how the script operates on commit messages, see [this branch on our public repository](http://github.com/mono/mono/commits/commit-to-changelog-tests).
+**Update**: ChangeLogs are no longer manually updated, instead just use the ChangeLog message on your commit. At release time, a script merges the commit messages into the proper ChangeLogs that are distributed. For a few examples on how the script operates on commit messages, see [this branch on our public repository](https://github.com/mono/mono/commits/commit-to-changelog-tests).
 
 You would typically commit your message like this:
 
@@ -1079,7 +1079,7 @@ Personal Work Branches
 
 See the description of [short term branches](/community/contributing/gitfaq/#workflow-2-use-master-as-integration-branch) and [long term branches](/community/contributing/gitfaq/#workflow-3-long-term-projects) in [GitFAQ](/community/contributing/gitfaq/).
 
-If you publish any feature branches, you should do so on forked repositories, not on the main mono module. Branches on repositories under [http://github.com/mono](http://github.com/mono) should be used for release engineering, bugfixes and integration; not for feature development.
+If you publish any feature branches, you should do so on forked repositories, not on the main mono module. Branches on repositories under [https://github.com/mono](https://github.com/mono) should be used for release engineering, bugfixes and integration; not for feature development.
 
 As somewhat of a corollary, you need to fork only when you publish your feature branch. After all, Git treats your local clone as a first-class repository, not just as a mirror of some remote repository. You *don't* need to fork to create local branches.
 

--- a/community/contributing/gitfaq.md
+++ b/community/contributing/gitfaq.md
@@ -8,9 +8,9 @@ redirect_from:
 Availability
 ============
 
-Mono is using GitHub's [Organizations](http://github.com/blog/674-introducing-organizations) functionality which allows us to keep all of the Mono modules that used to be hosted on our Subversion repository as repositories of the **mono** organization on GitHub.
+Mono is using GitHub's [Organizations](https://github.com/blog/674-introducing-organizations) functionality which allows us to keep all of the Mono modules that used to be hosted on our Subversion repository as repositories of the **mono** organization on GitHub.
 
-The Mono organization is available at [http://github.com/mono](http://github.com/mono)
+The Mono organization is available at [https://github.com/mono](https://github.com/mono)
 
 Windows Users
 =============
@@ -170,7 +170,7 @@ If you actually wanted a bugfix from 'master', just skip the last step, while ke
 
 If you want to publish the long-lived topic without integrating it into 'master', you should use a personal fork.
 
-This process is fairly efficient on Github. Go to the repository webpage and create a fork in your personal workspace. For instance, you take an origin repository `git://github.com/mono/mono.git` and fork it into `git@github.com:myrepos/mono.git` by going to `http://github.com/mono/mono` and clicking on the button marked "Fork".
+This process is fairly efficient on Github. Go to the repository webpage and create a fork in your personal workspace. For instance, you take an origin repository `git://github.com/mono/mono.git` and fork it into `git@github.com:myrepos/mono.git` by going to `https://github.com/mono/mono` and clicking on the button marked "Fork".
 
 You can add your personal fork as an additional remote with
 

--- a/community/contributing/source-code-repository.md
+++ b/community/contributing/source-code-repository.md
@@ -6,7 +6,7 @@ redirect_from:
   - /SVN/
 ---
 
-The Mono source code is hosted on [GitHub](http://GitHub.com) using the [Git](http://git-scm.com/) source code control system for all of its source code. Although only active contributors get write access to the modules on Git, third party developers and easily fork the code on GitHub or download full copies of the repositories to their own systems.
+The Mono source code is hosted on [GitHub](https://github.com) using the [Git](http://git-scm.com/) source code control system for all of its source code. Although only active contributors get write access to the modules on Git, third party developers and easily fork the code on GitHub or download full copies of the repositories to their own systems.
 
 Here we describe how one obtains commit access to the Mono Git repository and the responsibilities that come with that access privilege.
 

--- a/docs/about-mono/languages/csharp.md
+++ b/docs/about-mono/languages/csharp.md
@@ -113,13 +113,13 @@ The Mono C# compiler is part of the \`mono' module in the Mono Git you can get i
 
 You can also browse or download a snapshot of the compiler alone:
 
--   [browse the sources](http://github.com/mono/mono/tree/master/mcs/mcs/).
+-   [browse the sources](https://github.com/mono/mono/tree/master/mcs/mcs/).
 
 If you are interested in developing the C# compiler, the C# Compiler as a Service or the interactive shell on Windows we provide Visual Studio solutions that work on VS 2008 and 2010 and allow developers to quickly get the compiler up and running.
 
 To do this, download the entire MCS tree from:
 
--   [http://github.com/mono/mono/tree/master/mcs/](http://github.com/mono/mono/tree/master/mcs/).
+-   [https://github.com/mono/mono/tree/master/mcs/](https://github.com/mono/mono/tree/master/mcs/).
 
 And then open the Visual Studio solution on mcs/tools/csharp, this will build the Mono.CSharp.dll compiler as a service as well as the command line interactive C# shell "csharp".
 
@@ -136,7 +136,7 @@ When you report a bug, try to provide a small test case that would show the erro
 Implementation details
 ----------------------
 
-The compiler is documented in the file [mcs/docs/compiler](http://github.com/mono/mono/blob/master/mcs/docs/compiler.txt)
+The compiler is documented in the file [mcs/docs/compiler](https://github.com/mono/mono/blob/master/mcs/docs/compiler.txt)
 
 ### CIL Optimizations
 

--- a/docs/about-mono/languages/index.md
+++ b/docs/about-mono/languages/index.md
@@ -60,7 +60,7 @@ There are two possible choices here: PythonNet and IronPython.
 JavaScript
 ----------
 
-[IronJS](http://github.com/fholm/IronJS) is a DLR-based Javascript implementation that targets mono as well as .NET.
+[IronJS](https://github.com/fholm/IronJS) is a DLR-based Javascript implementation that targets mono as well as .NET.
 
 Historically mono used to ship 'mjs', an implementation of the JavaScript language as part of its distribution, the main author behind this effort is César Natarén.
 

--- a/docs/about-mono/releases/1.9.0.md
+++ b/docs/about-mono/releases/1.9.0.md
@@ -109,7 +109,7 @@ Implementation of the .NET 1.1 and 2.0 Design-Time framework [Ivan N. Zlatev].
 -   **WinForms Designers:** ComponentDesigner, ControlDesigner, ScrollableControlDesigner, ParentControlDesigner, DocumentDesigner, FormDocumentDesigner, PanelDesigner, SplitContainerDesigner, etc.
 -   **Services implementations provided:** UndoEngine, EventBindingService, MenuCommandsService, ISelectionService, IReferenceService, IExtenderProviderService, IExtenderListService, ITypeDescriptorFilterService, IDesignerHost, IComponentChangeService, etc.
 
-The implementation should be sufficient to implement at least a Windows Forms designer. An example can be found in the [mwf-designer](http://github.com/mono/mwf-designer/) module in our git repository. One major missing bit is the BehaviorService to aid the designer interaction.
+The implementation should be sufficient to implement at least a Windows Forms designer. An example can be found in the [mwf-designer](https://github.com/mono/mwf-designer/) module in our git repository. One major missing bit is the BehaviorService to aid the designer interaction.
 
 Class Libraries
 ---------------

--- a/docs/about-mono/releases/2.6.0.md
+++ b/docs/about-mono/releases/2.6.0.md
@@ -291,7 +291,7 @@ The **mdoc update** and **mdoc export-html** commands have been updated to honor
 
 **mdoc export-html** now behaves properly when multiple directories are provided as source parameters (e.g. *mdoc export-html -o html source1 source2 source3*), properly showing the union of all types within *html/index.html*.
 
-A new **mdoc export-html-webdoc** tool has been added which "pre-renders" XML documentation into partial HTML content for subsequent use by the [webdoc](http://github.com/mono/mono-tools/tree/master/webdoc) ASP.NET front-end. This can greatly reduce CPU load when displaying documentation.
+A new **mdoc export-html-webdoc** tool has been added which "pre-renders" XML documentation into partial HTML content for subsequent use by the [webdoc](https://github.com/mono/mono-tools/tree/master/webdoc) ASP.NET front-end. This can greatly reduce CPU load when displaying documentation.
 
 Installing Mono 2.6
 ===================

--- a/docs/about-mono/releases/2.6.1.md
+++ b/docs/about-mono/releases/2.6.1.md
@@ -309,7 +309,7 @@ The **mdoc update** and **mdoc export-html** commands have been updated to honor
 
 **mdoc export-html** now behaves properly when multiple directories are provided as source parameters (e.g. *mdoc export-html -o html source1 source2 source3*), properly showing the union of all types within *html/index.html*.
 
-A new **mdoc export-html-webdoc** tool has been added which "pre-renders" XML documentation into partial HTML content for subsequent use by the [webdoc](http://github.com/mono/mono-tools/tree/master/webdoc) ASP.NET front-end. This can greatly reduce CPU load when displaying documentation.
+A new **mdoc export-html-webdoc** tool has been added which "pre-renders" XML documentation into partial HTML content for subsequent use by the [webdoc](https://github.com/mono/mono-tools/tree/master/webdoc) ASP.NET front-end. This can greatly reduce CPU load when displaying documentation.
 
 Installing Mono 2.6.1
 =====================

--- a/docs/about-mono/releases/2.6.3.md
+++ b/docs/about-mono/releases/2.6.3.md
@@ -437,7 +437,7 @@ The **mdoc update** and **mdoc export-html** commands have been updated to honor
 
 **mdoc export-html** now behaves properly when multiple directories are provided as source parameters (e.g. *mdoc export-html -o html source1 source2 source3*), properly showing the union of all types within *html/index.html*.
 
-A new **mdoc export-html-webdoc** tool has been added which "pre-renders" XML documentation into partial HTML content for subsequent use by the [webdoc](http://github.com/mono/mono-tools/tree/master/webdoc) ASP.NET front-end. This can greatly reduce CPU load when displaying documentation.
+A new **mdoc export-html-webdoc** tool has been added which "pre-renders" XML documentation into partial HTML content for subsequent use by the [webdoc](https://github.com/mono/mono-tools/tree/master/webdoc) ASP.NET front-end. This can greatly reduce CPU load when displaying documentation.
 
 Installing Mono 2.6.3
 =====================

--- a/docs/about-mono/releases/2.6.4.md
+++ b/docs/about-mono/releases/2.6.4.md
@@ -475,7 +475,7 @@ The **mdoc update** and **mdoc export-html** commands have been updated to honor
 
 **mdoc export-html** now behaves properly when multiple directories are provided as source parameters (e.g. *mdoc export-html -o html source1 source2 source3*), properly showing the union of all types within *html/index.html*.
 
-A new **mdoc export-html-webdoc** tool has been added which "pre-renders" XML documentation into partial HTML content for subsequent use by the [webdoc](http://github.com/mono/mono-tools/tree/master/webdoc) ASP.NET front-end. This can greatly reduce CPU load when displaying documentation.
+A new **mdoc export-html-webdoc** tool has been added which "pre-renders" XML documentation into partial HTML content for subsequent use by the [webdoc](https://github.com/mono/mono-tools/tree/master/webdoc) ASP.NET front-end. This can greatly reduce CPU load when displaying documentation.
 
 Installing Mono 2.6.4
 =====================

--- a/docs/about-mono/releases/2.6.7.md
+++ b/docs/about-mono/releases/2.6.7.md
@@ -612,7 +612,7 @@ The **mdoc update** and **mdoc export-html** commands have been updated to honor
 
 **mdoc export-html** now behaves properly when multiple directories are provided as source parameters (e.g. *mdoc export-html -o html source1 source2 source3*), properly showing the union of all types within *html/index.html*.
 
-A new **mdoc export-html-webdoc** tool has been added which "pre-renders" XML documentation into partial HTML content for subsequent use by the [webdoc](http://github.com/mono/mono-tools/tree/master/webdoc) ASP.NET front-end. This can greatly reduce CPU load when displaying documentation.
+A new **mdoc export-html-webdoc** tool has been added which "pre-renders" XML documentation into partial HTML content for subsequent use by the [webdoc](https://github.com/mono/mono-tools/tree/master/webdoc) ASP.NET front-end. This can greatly reduce CPU load when displaying documentation.
 
 Installing Mono 2.6.7
 =====================

--- a/docs/about-mono/releases/4.2.1.md
+++ b/docs/about-mono/releases/4.2.1.md
@@ -172,7 +172,7 @@ adjusted to work with Mono's class libraries or have been updated to
 be cross platform.
 
 Changes made to Microsoft's reference source code are published under
-Mono's github organization fork at <http://github.com/mono/referencesource>
+Mono's github organization fork at <https://github.com/mono/referencesource>
 
 ### System assembly ###
 

--- a/docs/about-mono/supported-platforms/bsd.md
+++ b/docs/about-mono/supported-platforms/bsd.md
@@ -15,7 +15,7 @@ Mono on BSD operating systems is supported independently by the respective opera
 -   NetBSD [(Port)](http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/lang/mono/)
 -   OpenBSD ([Port](http://www.openbsd.org/cgi-bin/cvsweb/ports/lang/mono/))
 -   DragonflyBSD (Port: no official port)
--   [Debian GNU/kFreeBSD](http://www.debian.org/ports/kfreebsd-gnu/) [(Package)](http://packages.debian.org/unstable/interpreters/mono-runtime)
+-   [Debian GNU/kFreeBSD](http://www.debian.org/ports/kfreebsd-gnu/) [(Package)](https://packages.debian.org/unstable/interpreters/mono-runtime)
 
 Using Mono on the BSDs
 ======================

--- a/docs/advanced/runtime/docs/llvm-backend.md
+++ b/docs/advanced/runtime/docs/llvm-backend.md
@@ -42,13 +42,13 @@ The LLVM Mono Branch
 
 We maintain a fork/branch of LLVM with various changes to enable better integration with mono. The repo is at:
 
-[http://github.com/mono/llvm](http://github.com/mono/llvm)
+[https://github.com/mono/llvm](https://github.com/mono/llvm)
 
 The LLVM backend is currently only supported when using this version of LLVM. When using this version, it can compile about 99% of mscorlib methods.
 
 The GIT repo is forked from the unofficial LLVM git mirror at:
 
-[http://github.com/earl/llvm-mirror](http://github.com/earl/llvm-mirror)
+[https://github.com/earl/llvm-mirror](https://github.com/earl/llvm-mirror)
 
 ### Changes relative to stock LLVM
 
@@ -81,7 +81,7 @@ git diff `git merge-base mirror/master master`..master
 The master branch is maintained by regularly rebasing it on top of 'mirror/master'. This makes examining our changes easier. To merge changes from llvm-mirror to this repo, do:
 
 ``` bash
-git remote add mirror http://github.com/earl/llvm-mirror.git
+git remote add mirror https://github.com/earl/llvm-mirror.git
 git fetch mirror
 git rebase mirror/master
 <fix conflicts/commit>
@@ -236,5 +236,5 @@ LLVM has a LoopUnswitch pass which can do something like this for constant expre
 
 An experimental version of this optimization which can only handle simple cases is now in mono's llvm repository:
 
-[http://github.com/mono/llvm/tree/mono-abcrem](http://github.com/mono/llvm/tree/mono-abcrem)
+[https://github.com/mono/llvm/tree/mono-abcrem](https://github.com/mono/llvm/tree/mono-abcrem)
 

--- a/docs/compiling-mono/compiling-from-git.md
+++ b/docs/compiling-mono/compiling-from-git.md
@@ -6,7 +6,7 @@ redirect_from:
   - /Compiling_Mono_From_GIT/
 ---
 
-For full details about checking out your source code, see the [Mono page on GitHub](http://github.com/mono) page.
+For full details about checking out your source code, see the [Mono page on GitHub](https://github.com/mono) page.
 
 ### Checking out for the first time
 
@@ -59,7 +59,7 @@ make get-monolite-latest
 make
 ```
 
-The file [README.md](http://github.com/mono/mono/blob/master/README.md) contains more information about ways to compile Mono from the repository, consult it if you need more details.
+The file [README.md](https://github.com/mono/mono/blob/master/README.md) contains more information about ways to compile Mono from the repository, consult it if you need more details.
 
 Also to get the latest changes in System.Drawing.dll and System.Windows.Forms.dll you also need configure, build and install libgdiplus.
 

--- a/docs/compiling-mono/compiling-from-tarball.md
+++ b/docs/compiling-mono/compiling-from-tarball.md
@@ -8,7 +8,7 @@ If you are building versions of Mono prior to 2.8, you will need to obtain the M
 
 **Building From Packages**
 
-This applies to the officially [released packages](http://download.mono-project.com/sources/mono/).
+This applies to the officially [released packages](https://download.mono-project.com/sources/mono/).
 
 Unpack the Mono runtime distribution:
 

--- a/docs/compiling-mono/linux/index.md
+++ b/docs/compiling-mono/linux/index.md
@@ -30,7 +30,7 @@ Note: if you are using Ubuntu 15.04 or later, you also need to install the `libt
 Building Mono from a Release Package
 ------------------------------------
 
-Mono releases are distributed as .tar.bz2 packages from the [Mono web site](http://download.mono-project.com/sources/mono/). Once you have your dependencies installed all you need to do is run the following command where VERSION is the package version number and PREFIX is your installation prefix:
+Mono releases are distributed as .tar.bz2 packages from the [Mono web site](https://download.mono-project.com/sources/mono/). Once you have your dependencies installed all you need to do is run the following command where VERSION is the package version number and PREFIX is your installation prefix:
 
 ``` bash
 PREFIX=/usr/local

--- a/docs/compiling-mono/mac/index.md
+++ b/docs/compiling-mono/mac/index.md
@@ -40,10 +40,10 @@ PATH=$PREFIX/bin:$PATH
 # Download and build dependencies
 mkdir ~/Build
 cd ~/Build
-curl -O ftp://ftp.gnu.org/gnu/m4/m4-1.4.17.tar.gz
-curl -O ftp://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
-curl -O ftp://ftp.gnu.org/gnu/automake/automake-1.14.tar.gz
-curl -O ftp://ftp.gnu.org/gnu/libtool/libtool-2.4.2.tar.gz
+curl -O https://ftp.gnu.org/gnu/m4/m4-1.4.17.tar.gz
+curl -O https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
+curl -O https://ftp.gnu.org/gnu/automake/automake-1.14.tar.gz
+curl -O https://ftp.gnu.org/gnu/libtool/libtool-2.4.2.tar.gz
 
 for i in *.tar.gz; do tar xzvf $i; done
 for i in */configure; do (cd `dirname $i`; ./configure --prefix=$PREFIX && make && make install); done
@@ -111,10 +111,10 @@ PATH=$PREFIX/bin:$PATH
 # Download and build dependencies
 mkdir ~/Build
 cd ~/Build
-curl -O ftp://ftp.gnu.org/gnu/m4/m4-1.4.17.tar.gz
-curl -O ftp://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
-curl -O ftp://ftp.gnu.org/gnu/automake/automake-1.14.tar.gz
-curl -O ftp://ftp.gnu.org/gnu/libtool/libtool-2.4.2.tar.gz
+curl -O https://ftp.gnu.org/gnu/m4/m4-1.4.17.tar.gz
+curl -O https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
+curl -O https://ftp.gnu.org/gnu/automake/automake-1.14.tar.gz
+curl -O https://ftp.gnu.org/gnu/libtool/libtool-2.4.2.tar.gz
 
 for i in *.tar.gz; do tar xzvf $i; done
 for i in */configure; do (cd `dirname $i`; ./configure --prefix=$PREFIX && make && make install); done

--- a/docs/compiling-mono/parallel-mono-environments.md
+++ b/docs/compiling-mono/parallel-mono-environments.md
@@ -28,7 +28,7 @@ The "parallel" environment this document details is installed from either source
 
 ### Source Tarballs
 
-First, download the [Released Source Mono Tarballs](http://download.mono-project.com/sources/mono/). This document is concerned only with *mono*, *libgdiplus*, *gtk-sharp-1.x*, *gtk-sharp-2.x*, and *mono-tools*.
+First, download the [Released Source Mono Tarballs](https://download.mono-project.com/sources/mono/). This document is concerned only with *mono*, *libgdiplus*, *gtk-sharp-1.x*, *gtk-sharp-2.x*, and *mono-tools*.
 
 ### Source from Version Control (Mono Git)
 

--- a/docs/compiling-mono/windows/compiling-with-visualstudio.md
+++ b/docs/compiling-mono/windows/compiling-with-visualstudio.md
@@ -130,5 +130,5 @@ More informations
 
 Please email **\<mono-devel-list@lists.ximian.com\>** if you have any problem and/or if there's something wrong or missing in the instructions.
 
-An offline version of this document is available in the file [README.vsnet](http://github.com/mono/mono/blob/master/README.vsnet).
+An offline version of this document is available in the file [README.vsnet](https://github.com/mono/mono/blob/master/README.vsnet).
 

--- a/docs/debug+profile/profile/code-coverage.md
+++ b/docs/debug+profile/profile/code-coverage.md
@@ -11,7 +11,7 @@ For more information see [Profile](/docs/debug+profile/profile/).
 MonoCov
 =======
 
-MonoCov is made up of two components: a code coverage module, and a GUI interface for doing code coverage. This is available as part of the package "monocov" (available [here](http://github.com/mono/monocov)).
+MonoCov is made up of two components: a code coverage module, and a GUI interface for doing code coverage. This is available as part of the package "monocov" (available [here](https://github.com/mono/monocov)).
 
 To use it, run your program like this:
 

--- a/docs/getting-started/install/linux/index.md
+++ b/docs/getting-started/install/linux/index.md
@@ -68,11 +68,11 @@ openSUSE and SLES
 
 You can install using SUSE One-Click files (see below for descriptions):
 
-[![mono-devel](/images/OneClick.svg)](http://download.mono-project.com/repo/mono-devel.ymp) **mono-devel**
+[![mono-devel](/images/OneClick.svg)](https://download.mono-project.com/repo/mono-devel.ymp) **mono-devel**
 
-[![mono-complete](/images/OneClick.svg)](http://download.mono-project.com/repo/mono-complete.ymp) **mono-complete**
+[![mono-complete](/images/OneClick.svg)](https://download.mono-project.com/repo/mono-complete.ymp) **mono-complete**
 
-[![referenceassemblies-pcl](/images/OneClick.svg)](http://download.mono-project.com/repo/referenceassemblies-pcl.ymp) **referenceassemblies-pcl**
+[![referenceassemblies-pcl](/images/OneClick.svg)](https://download.mono-project.com/repo/referenceassemblies-pcl.ymp) **referenceassemblies-pcl**
 
 <hr/>
 

--- a/docs/getting-started/install/weekly-packages.md
+++ b/docs/getting-started/install/weekly-packages.md
@@ -7,12 +7,12 @@ The Mono project is making packages available containing the absolute latest cod
 Source Code
 -----------
 
-Source tarballs can be found [here](http://download.mono-project.com/sources/mono/nightly/)
+Source tarballs can be found [here](https://download.mono-project.com/sources/mono/nightly/)
 
 Mac OS X
 --------
 
-Mac OS X packages can be found [here](http://download.mono-project.com/archive/nightly/macos-10-universal/)
+Mac OS X packages can be found [here](https://download.mono-project.com/archive/nightly/macos-10-universal/)
 
 Debian, Ubuntu, and derivatives
 -------------------------------

--- a/docs/gui/gtksharp/index.md
+++ b/docs/gui/gtksharp/index.md
@@ -56,16 +56,16 @@ Our current stable release targets the GNOME 2.20 release.
 
 Current Source Releases:
 
--   [gtk-sharp](http://download.mono-project.com/sources/gtk-sharp212/)
--   [gnome-sharp](http://ftp.gnome.org/pub/gnome/sources/gnome-sharp/2.24/)
--   [gnome-desktop-sharp](http://ftp.gnome.org/pub/gnome/sources/gnome-desktop-sharp/2.26/)
+-   [gtk-sharp](https://download.mono-project.com/sources/gtk-sharp212/)
+-   [gnome-sharp](https://ftp.gnome.org/pub/gnome/sources/gnome-sharp/2.24/)
+-   [gnome-desktop-sharp](https://ftp.gnome.org/pub/gnome/sources/gnome-desktop-sharp/2.26/)
 
 [Packages and installers](/download/)
 
-Sources for releases up to 2.12.10 are available from [GNOME FTP](http://ftp.gnome.org/pub/gnome/sources/gtk-sharp),
-while later 2.12.x releases are only available from [MONO DOWNLOAD](http://download.mono-project.com/sources/gtk-sharp212/).
+Sources for releases up to 2.12.10 are available from [GNOME FTP](https://ftp.gnome.org/pub/gnome/sources/gtk-sharp),
+while later 2.12.x releases are only available from [MONO DOWNLOAD](https://download.mono-project.com/sources/gtk-sharp212/).
 
-Source packages for GTK#3 beta releases (2.99.x) are only available from [GNOME FTP](http://ftp.gnome.org/pub/gnome/sources/gtk-sharp).
+Source packages for GTK#3 beta releases (2.99.x) are only available from [GNOME FTP](https://ftp.gnome.org/pub/gnome/sources/gtk-sharp).
 
 ### GTK#3 porting guide
 

--- a/docs/gui/gtksharp/plan.md
+++ b/docs/gui/gtksharp/plan.md
@@ -18,7 +18,7 @@ We are now in stable bugfixing mode for the 2.4, 2.6, 2.8 and 2.10 bindings. The
 
 ### 2.12 bindings
 
-Gtk# 2.12 bindings are in stable release. Gnome# 2.20 and the new GnomeDesktop# unstable library bindings package have been released as well. Source tarballs are available from [GNOME FTP](http://ftp.gnome.org/pub/gnome/sources/gtk-sharp/2.12). See [GtkSharpNewInVersion2x](/docs/gui/gtksharp/new-in-version-2x/) for a list of enhancements and new features that were delivered in 2.12, along with newly bound API members from Gtk+ 2.12 and GNOME 2.20.
+Gtk# 2.12 bindings are in stable release. Gnome# 2.20 and the new GnomeDesktop# unstable library bindings package have been released as well. Source tarballs are available from [GNOME FTP](https://ftp.gnome.org/pub/gnome/sources/gtk-sharp/2.12). See [GtkSharpNewInVersion2x](/docs/gui/gtksharp/new-in-version-2x/) for a list of enhancements and new features that were delivered in 2.12, along with newly bound API members from Gtk+ 2.12 and GNOME 2.20.
 
 Release plan
 ------------

--- a/docs/gui/winforms/debugging-with-mwf.md
+++ b/docs/gui/winforms/debugging-with-mwf.md
@@ -13,7 +13,7 @@ Getting the MWF Project
 
 Download Mono's source tree from:
 
-[http://github.com/mono/mono](http://github.com/mono/mono)
+[https://github.com/mono/mono](https://github.com/mono/mono)
 
 Setting up the Environment
 --------------------------

--- a/docs/tools+libraries/libraries/Mono.Cecil/index.md
+++ b/docs/tools+libraries/libraries/Mono.Cecil/index.md
@@ -20,7 +20,7 @@ Versions
 
 Recently, Cecil undergone a large refactoring, to be able to fix some issues the previous version had. In its previous form, the code was compilable on a .net 1.0 profile, and you need to use Cecil from the 0.6 family if you still want to use it.
 
-For every other usage, you're urged to switch to the new version 0.9. Its development has been moved to the [Cecil github page](http://github.com/jbevain/cecil) until all the code in Mono is updated to this version.
+For every other usage, you're urged to switch to the new version 0.9. Its development has been moved to the [Cecil github page](https://github.com/jbevain/cecil) until all the code in Mono is updated to this version.
 
 Using Cecil
 ===========
@@ -50,7 +50,7 @@ And adding Mono.Cecil.dll as one of your dependencies.
 Download
 ========
 
-If you want the up to date version of Mono.Cecil, you need to get it from its [github page](http://github.com/jbevain/cecil).
+If you want the up to date version of Mono.Cecil, you need to get it from its [github page](https://github.com/jbevain/cecil).
 
 If you need a recent build of the 0.6 branch, the recommended way of quickly getting a binary of Mono.Cecil.dll, is to grab it from the last MonoCharge tarball which are part of our [daily builds](http://mono.ximian.com/daily/).
 

--- a/docs/tools+libraries/libraries/index.md
+++ b/docs/tools+libraries/libraries/index.md
@@ -523,7 +523,7 @@ Read the [Cecil](/docs/tools+libraries/libraries/Mono.Cecil/) on this site for m
 Mono.Reflection
 ---------------
 
-[Mono.Reflection](http://github.com/jbevain/mono.reflection/) is a helper library to complement the System.Reflection and System.Reflection.Emit with useful extension methods and helpers, including a IL disassembler.
+[Mono.Reflection](https://github.com/jbevain/mono.reflection/) is a helper library to complement the System.Reflection and System.Reflection.Emit with useful extension methods and helpers, including a IL disassembler.
 
 Bittorrent Libraries
 --------------------
@@ -616,7 +616,7 @@ You can read about how they ported NDO to work on Mono on their ["NDO runs under
 CouchDB access
 --------------
 
-The [Divan](http://github.com/gokr/Divan/tree/master) library can be used to access CouchDB servers.
+The [Divan](https://github.com/gokr/Divan/tree/master) library can be used to access CouchDB servers.
 
 DB4O
 ----

--- a/download/alpha.html
+++ b/download/alpha.html
@@ -11,7 +11,7 @@ redirect_from:
     <h1>Alpha Download</h1>
 
     <h5>The latest Alpha Mono release is: <strong>{{ site.data.alpharelease.version }}</strong></h5>
-    <p>Please choose your operating system to view the available packages. Source code is available on <a href="https://github.com/mono/mono">GitHub</a> or as a <a href="http://download.mono-project.com/sources/mono/">Tarball</a>.</p>
+    <p>Please choose your operating system to view the available packages. Source code is available on <a href="https://github.com/mono/mono">GitHub</a> or as a <a href="https://download.mono-project.com/sources/mono/">Tarball</a>.</p>
 
     <dl id="mono-download" class="tabs vertical" data-tab data-options="deep_linking: true; scroll_to_content: false">
       <dd class="active"><a href="#download-mac"><i class="fa fa-apple"></i>&nbsp;Mac OS X</a></dd>

--- a/download/beta.html
+++ b/download/beta.html
@@ -11,7 +11,7 @@ redirect_from:
     <h1>Beta Download</h1>
 
     <h5>The latest Beta Mono release is: <strong>{{ site.data.betarelease.version }}</strong></h5>
-    <p>Please choose your operating system to view the available packages. Source code is available on <a href="https://github.com/mono/mono">GitHub</a> or as a <a href="http://download.mono-project.com/sources/mono/">Tarball</a>.</p>
+    <p>Please choose your operating system to view the available packages. Source code is available on <a href="https://github.com/mono/mono">GitHub</a> or as a <a href="https://download.mono-project.com/sources/mono/">Tarball</a>.</p>
 
     <dl id="mono-download" class="tabs vertical" data-tab data-options="deep_linking: true; scroll_to_content: false">
       <dd class="active"><a href="#download-mac"><i class="fa fa-apple"></i>&nbsp;Mac OS X</a></dd>

--- a/download/index.html
+++ b/download/index.html
@@ -12,7 +12,7 @@ redirect_from:
     <h1>Download</h1>
 
     <h5>The latest Mono release is: <strong>{{ site.data.latestrelease.version }}</strong></h5>
-    <p>Please choose your operating system to view the available packages. Source code is available on <a href="https://github.com/mono/mono">GitHub</a> or as a <a href="http://download.mono-project.com/sources/mono/">Tarball</a>.</p>
+    <p>Please choose your operating system to view the available packages. Source code is available on <a href="https://github.com/mono/mono">GitHub</a> or as a <a href="https://download.mono-project.com/sources/mono/">Tarball</a>.</p>
 
     <dl id="mono-download" class="tabs vertical" data-tab data-options="deep_linking: true; scroll_to_content: false">
       <dd class="active"><a href="#download-mac"><i class="fa fa-apple"></i>&nbsp;Mac OS X</a></dd>
@@ -94,7 +94,7 @@ redirect_from:
     <p>Please visit the <a href="http://www.monodevelop.com/">MonoDevelop website</a> for more details about our cross-platform IDE.</p> 
 
     <h2>Older releases</h2>
-    <p>To access older Mono releases for OS X and Windows, check the <a href="http://download.mono-project.com/archive/">archive</a> on the download server. For Linux, please check the "Accessing older releases" section in the <a href="/docs/getting-started/install/linux/#accessing-older-releases">installation guide</a>.</p>
+    <p>To access older Mono releases for OS X and Windows, check the <a href="https://download.mono-project.com/archive/">archive</a> on the download server. For Linux, please check the "Accessing older releases" section in the <a href="/docs/getting-started/install/linux/#accessing-older-releases">installation guide</a>.</p>
 
     <h2>Alpha and Beta updates</h2>
     <p>To try pre-release packages, check the <a href="/download/alpha/">alpha</a> or <a href="/download/beta/">beta</a> download pages.</p>


### PR DESCRIPTION
There is no excuse to direct people to insecure download links when
https is available.

Changed links to websites:
- download.mono-project.com
- download.xamarin.com
- ftp.gnome.org
- ftp.gnu.org
- github.com (website is https-only)
- download.gnome.org (website is https-only)
- downloads.sourceforge.net (redirects browsers to https)
- packages.debian.org (website is https-only)

I didn't touch package manager links (Yum, APT, ...) because I presume
they are verified using digital signatures.
