### PR TITLE
mono_runtime_run_main crash if argc is zero

### DIFF
--- a/docs/advanced/embedding/index.md
+++ b/docs/advanced/embedding/index.md
@@ -127,8 +127,14 @@ In the above example, the contents of \`file.exe' will be loaded into the domain
 To start executing code, you must invoke a method in the assembly, or if you have provided a static Main method (an entry point), you can use the convenience function:
 
 ``` c
-retval = mono_jit_exec (domain, assembly, argc, argv);
+retval = mono_jit_exec (domain, assembly, argc - 1, argv + 1);
 ```
+
+And execute c program like:
+``` bash
+./c_program file.exe
+```
+> `mono_jit_exec` expects the assembly file name in argv[0], so we adjust c argc and argv a bit.
 
 Make sure you always provide a Main() method and execute it with `mono_jit_exec()` at startup: this sets up some additional information in the application domain, like the main assembly and the base loading path. You will be able to execute other methods even after Main() returns.
 

--- a/docs/advanced/embedding/index.md
+++ b/docs/advanced/embedding/index.md
@@ -134,7 +134,7 @@ And execute c program like:
 ``` bash
 ./c_program file.exe
 ```
-> `mono_jit_exec` expects the assembly file name in argv[0], so we adjust c argc and argv a bit.
+> `mono_jit_exec` expects the assembly file name in argv[0], so we adjust c argc and argv to respect the requirement.
 
 Make sure you always provide a Main() method and execute it with `mono_jit_exec()` at startup: this sets up some additional information in the application domain, like the main assembly and the base loading path. You will be able to execute other methods even after Main() returns.
 

--- a/docs/advanced/embedding/index.md
+++ b/docs/advanced/embedding/index.md
@@ -127,7 +127,7 @@ In the above example, the contents of \`file.exe' will be loaded into the domain
 To start executing code, you must invoke a method in the assembly, or if you have provided a static Main method (an entry point), you can use the convenience function:
 
 ``` c
-retval = mono_jit_exec (domain, assembly, argc - 1, argv + 1);
+retval = mono_jit_exec (domain, assembly, argc, argv);
 ```
 
 Make sure you always provide a Main() method and execute it with `mono_jit_exec()` at startup: this sets up some additional information in the application domain, like the main assembly and the base loading path. You will be able to execute other methods even after Main() returns.


### PR DESCRIPTION
env 
libmonosgen-2_0-1 x86_64  v4.6.2.7

```
#include <stdio.h>

#include <mono/jit/jit.h>
#include <mono/metadata/assembly.h>

int main(int argc, char **argv) {
	MonoDomain *domain = 0;
	MonoAssembly *assembly = 0;
	int retval = 0;

	domain = mono_jit_init("csharp_program.exe");
	assembly = mono_domain_assembly_open (domain, "csharp_program.exe");
	if (!assembly) {
		printf("%s", "mono_domain_assembly_open failed\n");
		return 1;
	}
	retval = mono_jit_exec (domain, assembly, argc, argv);
	printf("mono_jit_exec return with code %d\n", retval);

	return 0;
}
```

```
gcc main.c `pkg-config --cflags --libs mono-2`
./a.out
```
crash at https://github.com/mono/mono/blob/mono-4.6.0-branch/mono/metadata/object.c#L4090