### PR TITLE
Fix URLs for GTK# for Windows packages

### DIFF
--- a/_data/betarelease.yml
+++ b/_data/betarelease.yml
@@ -2,4 +2,4 @@ version: 4.6 Service Release 2 (4.6.2.16)
 mono_mac_url: https://download.mono-project.com/archive/4.6.2/macos-10-universal/MonoFramework-MDK-4.6.2.16.macos10.xamarin.universal.pkg
 mono_windows_url: https://download.mono-project.com/archive/4.6.2/windows-installer/mono-4.6.2.16-gtksharp-2.12.42-win32-0.msi
 mono_windows64_url: https://download.mono-project.com/archive/4.6.2/windows-installer/mono-4.6.2.16-x64-0.msi
-gtksharp_windows_url: https://download.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.42.msi
+gtksharp_windows_url: https://dl.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.42.msi

--- a/_data/latestrelease.yml
+++ b/_data/latestrelease.yml
@@ -2,4 +2,4 @@ version: 4.6 Service Release 2 (4.6.2.16)
 mono_mac_url: https://download.mono-project.com/archive/4.6.2/macos-10-universal/MonoFramework-MDK-4.6.2.16.macos10.xamarin.universal.pkg
 mono_windows_url: https://download.mono-project.com/archive/4.6.2/windows-installer/mono-4.6.2.16-gtksharp-2.12.42-win32-0.msi
 mono_windows64_url: https://download.mono-project.com/archive/4.6.2/windows-installer/mono-4.6.2.16-x64-0.msi
-gtksharp_windows_url: https://download.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.42.msi
+gtksharp_windows_url: https://dl.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.42.msi


### PR DESCRIPTION
The download link on the website is broken:

http://www.mono-project.com/download/#download-win

/cc @directhex 