### PR TITLE
Split Ubuntu and Debian install instructions

### DIFF
--- a/docs/getting-started/install/linux/index.md
+++ b/docs/getting-started/install/linux/index.md
@@ -9,7 +9,7 @@ redirect_from:
 
 Regardless of your distribution, you will need the Mono Project GPG signing key, which package managers require.
 
-Debian, Ubuntu, and derivatives
+Ubuntu and derivatives
 -------------------------------
 
 Add the Mono Project GPG signing key and the package repository to your system (if you don't use sudo, be sure to switch to root):
@@ -24,20 +24,12 @@ Run a package upgrade to upgrade existing packages to the latest available. Then
 
 *Note:* While the APT package is built against Debian Wheezy, it is compatible with a number of Debian derivatives (including Ubuntu) which means you can use the same repository across all these distributions.
 
-#### mod_mono (Ubuntu 13.10 and later, Debian 8.0 and later)
+#### mod_mono (Ubuntu 13.10 and later)
 
-To enable mod_mono installation on Ubuntu 13.10 and later, and Debian 8.0 and later (and their derivatives), you will need to add a second repository to your system, **in addition** to the generic Debian/Ubuntu repository above (if you don't use sudo, be sure to switch to root):
+To enable mod_mono installation on Ubuntu 13.10 and later (and their derivatives), you will need to add a second repository to your system, **in addition** to the generic Debian/Ubuntu repository above (if you don't use sudo, be sure to switch to root):
 
 ``` bash
 echo "deb http://download.mono-project.com/repo/debian wheezy-apache24-compat main" | sudo tee -a /etc/apt/sources.list.d/mono-xamarin.list
-```
-
-#### libgdiplus (Debian 8.0 and later, NOT Ubuntu)
-
-To enable libgdiplus installation on Debian 8.0 and later (and their derivatives), you will need to add a second repository to your system, **in addition** to the generic Debian/Ubuntu repository above (if you don't use sudo, be sure to switch to root):
-
-``` bash
-echo "deb http://download.mono-project.com/repo/debian wheezy-libjpeg62-compat main" | sudo tee -a /etc/apt/sources.list.d/mono-xamarin.list
 ```
 
 #### Older Ubuntu releases (Ubuntu 12.10 and 12.04)
@@ -47,6 +39,38 @@ To enable installation on older Ubuntu releases such as Ubuntu 12.04 and Ubuntu 
 ``` bash
 echo "deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main" | sudo tee -a /etc/apt/sources.list.d/mono-xamarin.list
 ```
+
+Debian and derivatives
+-------------------------------
+
+Add the Mono Project GPG signing key and the package repository to your system (if you don't use sudo, be sure to switch to root):
+
+``` bash
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
+sudo apt-get update
+```
+
+Run a package upgrade to upgrade existing packages to the latest available. Then install Mono as described in the [Usage](#usage) section.
+
+*Note:* While the APT package is built against Debian Wheezy, it is compatible with a number of Debian derivatives (including Ubuntu) which means you can use the same repository across all these distributions.
+
+#### mod_mono (Debian 8.0 and later)
+
+To enable mod_mono installation on Debian 8.0 and later (and their derivatives), you will need to add a second repository to your system, **in addition** to the generic Debian repository above (if you don't use sudo, be sure to switch to root):
+
+``` bash
+echo "deb http://download.mono-project.com/repo/debian wheezy-apache24-compat main" | sudo tee -a /etc/apt/sources.list.d/mono-xamarin.list
+```
+
+#### libgdiplus (Debian 8.0 and later)
+
+To enable libgdiplus installation on Debian 8.0 and later (and their derivatives), you will need to add a second repository to your system, **in addition** to the generic Debian repository above (if you don't use sudo, be sure to switch to root):
+
+``` bash
+echo "deb http://download.mono-project.com/repo/debian wheezy-libjpeg62-compat main" | sudo tee -a /etc/apt/sources.list.d/mono-xamarin.list
+```
+
 
 CentOS 7, Fedora 19 (and later), and derivatives
 -------------------------------

--- a/docs/getting-started/install/linux/index.md
+++ b/docs/getting-started/install/linux/index.md
@@ -10,7 +10,7 @@ redirect_from:
 Regardless of your distribution, you will need the Mono Project GPG signing key, which package managers require.
 
 Ubuntu and derivatives
--------------------------------
+----------------------
 
 Add the Mono Project GPG signing key and the package repository to your system (if you don't use sudo, be sure to switch to root):
 
@@ -41,7 +41,7 @@ echo "deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat mai
 ```
 
 Debian and derivatives
--------------------------------
+----------------------
 
 Add the Mono Project GPG signing key and the package repository to your system (if you don't use sudo, be sure to switch to root):
 


### PR DESCRIPTION
Avoids confusion with libgdiplus causing "broken packages" on Ubuntu if accidentally added.

For example of the confusion, see [here](https://askubuntu.com/questions/729409/cannot-install-mono-depends-errors) (I also hit this bug and so wanted to contribute back to the docs).