### PR TITLE
Update 5.0 notes with the NoAsyncCurrentCulture breakage

### DIFF
--- a/docs/about-mono/releases/5.0.0.md
+++ b/docs/about-mono/releases/5.0.0.md
@@ -28,9 +28,7 @@ In Depth
 Breaking changes
 ----------------
 
-Mono 5.0 implements the dotnet 4.6 behavior regarding CultureInfo.CurrentCulture and CultureInfo.CurrentUICulture. On previous versions they used to be stored on thread-locals but now are stored on the execution context, meaning their values follow async Tasks. For more information see [MSDN page] (https://msdn.microsoft.com/en-us/library/mt761774.aspx)
-
-On the current release is not possible to revert to the old behavior using AppContextSwitches, this should change in future releases.
+Mono 5.0 implements the .NET 4.6 behavior regarding CultureInfo.CurrentCulture and CultureInfo.CurrentUICulture. On previous versions they used to be stored on thread-locals but now are stored on the execution context, meaning their values follow async Tasks. For more information see [MSDN page](https://msdn.microsoft.com/en-us/library/mt761774.aspx)
 
 C# compiler
 -----------

--- a/docs/about-mono/releases/5.0.0.md
+++ b/docs/about-mono/releases/5.0.0.md
@@ -25,6 +25,13 @@ Highlights
 In Depth
 ========
 
+Breaking changes
+----------------
+
+Mono 5.0 implements the dotnet 4.6 behavior regarding CultureInfo.CurrentCulture and CultureInfo.CurrentUICulture. On previous versions they used to be stored on thread-locals but now are stored on the execution context, meaning their values follow async Tasks. For more information see [MSDN page] (https://msdn.microsoft.com/en-us/library/mt761774.aspx)
+
+On the current release is not possible to revert to the old behavior using AppContextSwitches, this should change in future releases.
+
 C# compiler
 -----------
 


### PR DESCRIPTION
This will change once https://github.com/mono/mono/pull/4682 gets merged.