### PR TITLE
Various improvements to the 5.0 release notes

### DIFF
--- a/docs/about-mono/releases/5.0.0.md
+++ b/docs/about-mono/releases/5.0.0.md
@@ -30,22 +30,32 @@ C# compiler
 
 ### csc
 
-The [Roslyn](https://github.com/dotnet/roslyn) C# compiler is now available on Mono and it's called `csc`. It's the same compiler available on Windows / Visual Studio with full support for C#7. Both `msbuild` and `xbuild` have been updated to call the `csc` compiler under the hood instead of `mcs`.
+The [Roslyn](https://github.com/dotnet/roslyn) C# compiler is now available on Mono and it's called `csc`. It's the same compiler available on Windows / Visual Studio with [full support for C# 7](https://docs.microsoft.com/en-us/dotnet/articles/csharp/whats-new/csharp-7). Both `msbuild` and `xbuild` have been updated to call the `csc` compiler under the hood instead of `mcs`.
 
 Replacing `mcs` with `csc` in user scripts should be straightforward but small issues can arise as command line arguments accepted by `csc` and features are not identical to `mcs`. For example, `csc` generates Portable PDB (.pdb) debug files instead of Mono's MDB (.mdb) format. It also can't do full signing on non-Windows platforms, use the `/publicsign` switch instead or use delay signing and sign the assembly with the `sn` tool after the build.
 
-The following new C#7 features are now available:
+#### C# 7 adds a number of new features to the C# language: ####
 
-* Tuples
-* Pattern Matching
-* Local Functions
-* Extended expression bodied members
-* out var declaration
-* Binary literals
-* Digit separators
-* Generalized async return types
-* throw expressions
-* ref locals and returns
+* [`out` variables](https://docs.microsoft.com/en-us/dotnet/articles/csharp/whats-new/csharp-7#out-variables):
+    - You can declare `out` values inline as arguments to the method where they are used.
+* [Tuples](https://docs.microsoft.com/en-us/dotnet/articles/csharp/whats-new/csharp-7#tuples)
+    - You can create lightweight, unnamed types that contain multiple public fields. Compilers and IDE tools understand the semantics of these types.
+* [Pattern Matching](https://docs.microsoft.com/en-us/dotnet/articles/csharp/whats-new/csharp-7#pattern-matching)
+    - You can create branching logic based on arbitrary types and values of the members of those types.
+* [`ref` locals and returns](https://docs.microsoft.com/en-us/dotnet/articles/csharp/whats-new/csharp-7#ref-locals-and-returns)
+    - Method arguments and local variables can be references to other storage.
+* [Local Functions](https://docs.microsoft.com/en-us/dotnet/articles/csharp/whats-new/csharp-7#local-functions)
+    - You can nest functions inside other functions to limit their scope and visibility.
+* [More expression-bodied members](https://docs.microsoft.com/en-us/dotnet/articles/csharp/whats-new/csharp-7#more-expression-bodied-members)
+    - The list of members that can be authored using expressions has grown.
+* [`throw` Expressions](https://docs.microsoft.com/en-us/dotnet/articles/csharp/whats-new/csharp-7#throw-expressions)
+    - You can throw exceptions in code constructs that previously were not allowed because `throw` was a statement. 
+* [Generalized async return types](https://docs.microsoft.com/en-us/dotnet/articles/csharp/whats-new/csharp-7#generalized-async-return-types)
+    - Methods declared with the `async` modifier can return other types in addition to `Task` and `Task<T>`.
+* [Numeric literal syntax improvements](https://docs.microsoft.com/en-us/dotnet/articles/csharp/whats-new/csharp-7#numeric-literal-syntax-improvements)
+    - New tokens improve readability for numeric constants.
+
+The new features in C# 7 can also be [explored interactively](https://developer.xamarin.com/workbooks/#csharp-csharp-7) as a Xamarin Workbook.
 
 ### mcs
 

--- a/docs/about-mono/releases/5.0.0.md
+++ b/docs/about-mono/releases/5.0.0.md
@@ -88,6 +88,22 @@ Tools
 
 The `pdb2mdb` tool was updated so it no longer crashes when run against an assembly that has a Portable PDB debug symbols available.
 
+### `csharp`
+
+The `csharp` REPL and scripting tool, which is based on the `mcs` compiler,
+now supports script-and-REPL-specific command line arguments, which are
+delimited by either the `-s` or `--` arguments. These arguments are further
+made available in the `Args` global for easy processing in scripts.
+
+It is now possible to write [self-executing scripts with simple and
+unambiguous access to command line arguments](https://gist.github.com/abock/54f0c2091c063eca88891b969dfce504):
+
+```csharp
+#!/usr/bin/env csharp -s
+
+Args.Length
+```
+
 ### nunit
 
 Deprecation of Mono-bundled version of NUnit:

--- a/docs/about-mono/releases/5.0.0.md
+++ b/docs/about-mono/releases/5.0.0.md
@@ -20,7 +20,7 @@ Highlights
 * [Enabling concurrent SGen garbage collector](#sgen-improvements) to reduce time spent in GC
 * [Introducing the AppleTLS stack](#appletls-stack) on macOS for HTTPS connections
 * [Continued Progress on .NET Class Library convergence](#corefx--reference-source-adoption)
-* [Updated libjpg in MacOS package](#libjpg-update-in-macos-package)
+* [Updated libjpeg in macOS package](#libjpeg-update-in-macos-package)
 
 In Depth
 ========
@@ -30,9 +30,9 @@ C# compiler
 
 ### csc
 
-The [Roslyn](https://github.com/dotnet/roslyn) C# compiler is now available on Mono and it's called `csc`. It's the same compiler available on Windows / Visual Studio with full support for C#7. Both msbuild and xbuild have been updated to call the `csc` compiler under the hood instead of `mcs`.
+The [Roslyn](https://github.com/dotnet/roslyn) C# compiler is now available on Mono and it's called `csc`. It's the same compiler available on Windows / Visual Studio with full support for C#7. Both `msbuild` and `xbuild` have been updated to call the `csc` compiler under the hood instead of `mcs`.
 
-Replacing `mcs` with `csc` in user scripts should be straightforward but small issues can arise as command line arguments accepted by csc and features are not identical to mcs. For example, `csc` generates Portable PDB (.pdb) debug files instead of Mono's MDB (.mdb) format. It also can't do full signing on non-Windows platforms, use the `/publicsign` switch instead or use delay signing and sign the assembly with the `sn` tool after the build.
+Replacing `mcs` with `csc` in user scripts should be straightforward but small issues can arise as command line arguments accepted by `csc` and features are not identical to `mcs`. For example, `csc` generates Portable PDB (.pdb) debug files instead of Mono's MDB (.mdb) format. It also can't do full signing on non-Windows platforms, use the `/publicsign` switch instead or use delay signing and sign the assembly with the `sn` tool after the build.
 
 The following new C#7 features are now available:
 
@@ -54,12 +54,12 @@ The Mono C# compiler is still available but it has not been updated to include C
 MSBuild
 -------
 
-Over the past year we have been working to integrate the opensourced `msbuild` build
+Over the past year we have been working to integrate the open-sourced `msbuild` build
 tool into Mono. It is now available as part of your Mono installation, and it is
 the same [MSBuild](https://github.com/Microsoft/msbuild) that is used
 on .NET on Windows.
 
-Thie resolves numerous incompatibilities we had in our previous `xbuild` implementation.
+This resolves numerous incompatibilities we had in our previous `xbuild` implementation.
 
 ### xbuild
 
@@ -67,7 +67,7 @@ Mono's historical implementation of MSBuild called `xbuild` is now deprecated. W
 
 ### Reference assemblies
 
-The reference assemblies were updated to fully match the .NET 4.6.2 API set. This means that you no longer get compilation errors about missing classes/methods when building against one of the .NET profiles via msbuild/xbuild.
+The reference assemblies were updated to fully match the .NET 4.6.2 API set. This means that you no longer get compilation errors about missing classes/methods when building against one of the .NET profiles via `msbuild`/`xbuild`.
 
 Note that at runtime certain APIs that Mono doesn't (yet) implement will still throw an exception.
 
@@ -80,12 +80,12 @@ The `pdb2mdb` tool was updated so it no longer crashes when run against an assem
 
 ### nunit
 
-Deprecation of Mono bundled version of NUnit:
+Deprecation of Mono-bundled version of NUnit:
 
 Mono used to ship with a forked copy of NUnit 2.4 that we used for testing Mono itself.
 For historical reasons it was never updated and is ancient at this point (it was released nearly 10 years ago!).
 
-We moved to nunitlite for testing Mono so we decided to deprecate the version we ship.
+We moved to NUnitLite for testing Mono so we decided to deprecate the version we ship.
 
 The `nunit-console` command will print a warning now. Compiling new projects against the NUnit DLLs from GAC
 will fail with an error message (existing test assemblies continue to work).
@@ -129,9 +129,9 @@ Mono managed TLS 1.0 stack.   From your shell, you can do it like this:
 export MONO_TLS_PROVIDER=legacy
 ```
 
-libJPG Update in MacOS Package
+libjpeg Update in macOS Package
 ------------------------------
-The MacOS SDK package now contains an updated libjpeg library that resolves the issue described in [CVE-2013-6629](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-6629). Our Mono distribution for the Mac now includes an updated libjpg.
+The macOS SDK package now contains an updated libjpeg library that resolves the issue described in [CVE-2013-6629](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-6629). Our Mono distribution for macOS now includes an updated libjpeg.
 
 Runtime
 -------
@@ -145,25 +145,26 @@ classes, which are part of the official .NET class libraries.
 
 ### Environment Memory Management And System.Configuration ###
 
-As per the Unix specification, getenv may return a pointer into static memory. Future calls to getenv can overwrite
-the memory returned from previous calls to getenv. Mono kept many pointers into this memory while concurrently calling
-getenv on multiple threads. We now lock around the environment-changing functions and to duplicate all returned strings.
+As per the Unix specification, `getenv` may return a pointer into static memory. Future calls to `getenv` can overwrite
+the memory returned from previous calls to `getenv`. Mono kept many pointers into this memory while concurrently calling
+`getenv` on multiple threads. We now lock around the environment-changing functions and to duplicate all returned strings.
+
 Unfortunately, Mono will use the environment to find which configuration file to read for System.Configuration.
 Configurations that were set might not have been used, as managed code was seeing nulls. This is how the bug surfaced, it
 is not hypothetical. Users who set a custom configuration file (via `MONO_CFG_DIR`) are encouraged to check that using
 previously-ignored configuration files does not lead to unexpected breakage.
 
-### Match semantics of rethrow instruction with .NET runtime ###
+### Match semantics of `rethrow` instruction with .NET runtime ###
 
 Mono used to cut off the stack trace at the point where an exception is
-rethrown, however, it should retain the stack trace if `rethrow` [is
+re-thrown, however, it should retain the stack trace if `rethrow` [is
 used](https://msdn.microsoft.com/en-us/library/ms182363.aspx).
 
 ### Experimental runtime interpreter ###
 
 We revived the interpreter back from the old days (aka. `mint`).  It now
 supports generics, and was updated to match internal API changes. It is
-disabled per default and shouldn't be used in production yet.
+disabled by default and shouldn't be used in production yet.
 
 The interpreter will be an execution option to the current runtime.
 
@@ -181,18 +182,18 @@ and make the codebase easier to navigate and understand.
 
 ### Lazy array interfaces ###
 
-One curious aspect of C# is that arrays implement invarient interfaces as if they were covariant. This happens for `IList<T>, ICollection<T> and IEnumerable<T>` which means, for example, that `string[]` implements both `IList<string>` and `IList<object>`.
+One curious aspect of C# is that arrays implement invariant interfaces as if they were covariant. This happens for `IList<T>`, `ICollection<T>` and `IEnumerable<T>` which means, for example, that `string[]` implements both `IList<string>` and `IList<object>`.
 
 Mono traditionally implemented this by creating the runtime-side metadata for all of those interfaces and that came with an extraordinary memory cost of creating a lot of interfaces that never ended up being referenced by C# code.
 
-With Mono 5.0 we now treat those interfaces as magic/special and use a different casting codepath. This allow them to be lazily implemented in arrays, which can save a lot of memory in LINQ-heavy workloads. As part of this work we refactored the casting code in the JIT to be simpler and more maintainable.
+With Mono 5.0 we now treat those interfaces as magic/special and use a different casting code-path. This allows them to be lazily implemented in arrays, which can save a lot of memory in LINQ-heavy workloads. As part of this work we refactored the casting code in the JIT to be simpler and more maintainable.
 
 ### Memory usage ###
 
 Improvements in the runtime representation of the type system should yield a 5% memory saving
-in most workloads. It was archieved by using a more efficient representation for arrays and generic instances.
+in most workloads. It was achieved by using a more efficient representation for arrays and generic instances.
 
-A linearalizable property bag was added to replace the current mechanism of rare fields in runtime metadata.
+A linearizable property bag was added to replace the current mechanism of rare fields in runtime metadata.
 More rarely used fields were moved to use it as they now use significantly less memory when used.
 
 ### SGen Improvements ###
@@ -218,7 +219,7 @@ strategy.
 This release includes some performance improvements in ephemeron
 processing, which also translate to shorter collections. Ephemerons
 are an internal structure used by the SGen to implement the semantics
-of ConditionalWeakTable. This also includes a fix for a long-standing
+of `ConditionalWeakTable`. This also includes a fix for a long-standing
 leak when using and disposing of a lot of these structures.
 
 Major block allocation and freeing was tweaked in order to reduce
@@ -246,15 +247,15 @@ collector.
 
 The runtime crash stack traces now include information on managed stack traces to allow them to be symbolificated. Tooling was adjusted to handle the slightly different format.
 
-### Thread.Abort harderning ###
+### `Thread.Abort` hardening ###
 
 The runtime was hardened to further its resilience in face of thread aborts.
 It now won't abort in-flight class constructors.
-Thread abort is important for application using multiple AppDomains.
+Thread abort is important for application using multiple `AppDomain`s.
 
-### Thread Abort Exception ###
+### `ThreadAbortException` ###
 
-ThreadAbortException remains set during stack unwinding unless manually unset. While inside of a function call inside of a catch block for the exception, it was possible for us to see the set ThreadAbortException and behave as if the call inside of the catch block threw it. This has been fixed.
+`ThreadAbortException` remains set during stack unwinding unless manually unset. While inside of a function call inside of a catch block for the exception, it was possible for us to see the set `ThreadAbortException` and behave as if the call inside of the catch block threw it. This has been fixed.
 
 ### Unwinding on Android ###
 
@@ -268,9 +269,9 @@ We changed our approach by trying to do _less_ work: We now rely on a system
 process by Android aka. `debuggerd` to provide us a native stack trace. On some
 Android versions this requires us to set `DUMPABLE`.
 
-### Workaround for netstandard nugets on desktop ###
+### Workaround for .NET Standard NuGets on desktop ###
 
-Some netstandard NuGets like System.IO.Compression resolve to assemblies that won't work with Mono on Desktop. To handle this we implemented a series of workarounds:
+Some .NET Standard NuGets like `System.IO.Compression` resolve to assemblies that won't work with Mono on Desktop. To handle this we implemented a series of workarounds:
 
 * Deny loading problematic assemblies. They will be handled as if they did not exist
 * Deny remapping to problematic assembly versions. The system version will be used instead.


### PR DESCRIPTION
1. fix typos and formatting in many places
2. spruce up the C# 7 blurb
3. add `csharp` scripting improvement