### PR TITLE
Update repl.md

### DIFF
--- a/docs/tools+libraries/tools/repl.md
+++ b/docs/tools+libraries/tools/repl.md
@@ -228,7 +228,7 @@ csharp>
 Startup Files
 =============
 
-On startup the csharp shell will load any C# script files and
+On startup the csharp shell will load any C# script files (ending with .cs) and
 pre-compiled libraries (ending with .dll) that are located in the
 \~/.config/csharp directory (on Windows this is the value of
 Environment.GetFolderPath


### PR DESCRIPTION
Clarified that when loading C# script files the filenames should end in .cs as it appears that .csx and other possible options do not work.