### PR TITLE
Update the articles about Clang's sanitisers

### DIFF
--- a/docs/debug+profile/clang/addresssanitizer.md
+++ b/docs/debug+profile/clang/addresssanitizer.md
@@ -1,0 +1,38 @@
+---
+title: AddressSanitizer (Clang Sanitizers)
+---
+
+The [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) is integrated into [Clang](https://clang.llvm.org/) 3.4+ and therefore, if Clang is installed, using it with Mono's `autogen.sh` is as simple as running the following:
+
+``` bash
+$ cd /home/root/of/mono
+$ ./autogen.sh --prefix=/usr/local CC=clang CFLAGS=-fsanitize=address LDFLAGS=-fsanitize=address CXX=clang++
+$ make
+...
+```
+
+Please keep in mind that `CXX` has to be set to `clang++` to avoid unwanted side effects and compiling errors.
+
+After `autogen.sh` has been executed as suggested above, the following `make` command uses Clang and injects necessary reporting functions.
+
+In the context of Mono, the AddressSanitizer (without the LeakSanitizer, [see below](#ignore-the-leaks)) produces a lot less false positives than the [ThreadSanitizer](/docs/debug+profile/clang/threadsanitizer/), which makes working with it more straight forward.
+
+Dynamic Blacklisting
+--------------------
+
+Still, false positives need to be hidden, and so far, the best option is to work with blacklists. Please have a look at [this article](/docs/debug+profile/clang/blacklists/) to find out how to work with blacklists in combination with Mono.
+
+Since there are only a handful of false positives, no macros or special functions can be used to permanently blacklist anything directly within the code (August 2017).
+
+Runtime Options
+---------------
+
+Runtime options can be provided by using the environment variable `ASAN_OPTIONS`. Please find detailed information about runtime options and Mono in [this article](/docs/debug+profile/clang/customisation/#runtime-options) and all available options on [Google's GitHub page](https://github.com/google/sanitizers/wiki/AddressSanitizerFlags#run-time-flags). The following two options prove to be particularly useful:
+
+### Ignore the Leaks
+
+By default, the AddressSanitizer starts the [LeakSanitizer](https://clang.llvm.org/docs/LeakSanitizer.html) as soon as the program terminates otherwise successfully. In the context of Mono this means several 100 (sometimes up to a few 1000) reported leaks. `detect_leaks=0` tells the AddressSanitizer to shut down without starting the LeakSanitizer.
+
+### Never Stop
+
+If not told otherwise, the AddressSanitizer exits the program after detecting the first error. While this is helpful when debugging a specific issue, it can be an unwanted side effect when trying to find all problems of a program at once. Using `halt_on_error=false` can help there.

--- a/docs/debug+profile/clang/blacklists.md
+++ b/docs/debug+profile/clang/blacklists.md
@@ -1,0 +1,49 @@
+---
+title: Blacklists (Clang Sanitizers)
+---
+
+A blacklist file contains the names of source files and/or functions whose issues (races, leaks, ...) should not be reported. Such blacklist files can be placed anywhere on the system. For the sake of simplicity, this article will focus on working with the [ThreadSanitizer](/docs/debug+profile/clang/threadsanitizer/). However, the same concepts and rules apply for all [Clang sanitizers](/docs/debug+profile/clang/) when used in combination with Mono.
+
+The simplest approach (an empty blacklist) would look like this:
+
+``` bash
+$ touch /home/some/path/blacklist
+$ cd /home/root/of/mono
+$ ./autogen.sh --prefix=/usr/local CC=clang CFLAGS="-fsanitize=thread -fsanitize-blacklist=/home/some/path/blacklist" LDFLAGS=-fsanitize=thread CXX=clang++
+$ make
+...
+```
+
+The easiest way of blocking everything is to simply put `src:*` into the blacklist file:
+
+``` bash
+$ cat /home/some/path/blacklist
+src:*
+```
+
+However, a finer granularity (toggling the reporting of functions instead of the reporting of whole source files) is often desirable. Currently, `fun:` can be used to achieve that. Also, `src:` and `fun:` can be used in the same blacklist file and even the usage of wildcards (`*`) is supported. Please have a look at the [official documentation](https://clang.llvm.org/docs/SanitizerSpecialCaseList.html) for more details.
+
+Partitioning Blacklists
+-----------------------
+
+Changes of blacklist files are detected automatically. The first `make` command after changing a blacklist file recompiles all source files that use that specific blacklist file for compilation. While this is very useful, it wastes a lot of CPU and time to recompile the whole project when only debugging / toggling a few functions of a specific module. One way of working with blacklists more efficiently is to partition the blocked functions and source files into dedicated files. To link those dedicated blacklists to Clang, all corresponding `Makefile` files have to be altered.
+
+For example, if `mono/sgen/` was to be debugged, a setup could look like this:
+
+``` bash
+$ cd /home/root/of/mono
+$ ./autogen.sh --prefix=/usr/local CC=clang CFLAGS="-fsanitize=thread -fsanitize-blacklist=/home/some/path/blacklist" LDFLAGS=-fsanitize=thread CXX=clang++
+$ cat /home/some/path/blacklist-sgen
+fun:sweep_block
+fun:sweep_block_for_size
+$ # alter mono/sgen/Makefile
+$ cat mono/sgen/Makefile
+...
+CCASFLAGS = -fsanitize=thread -fsanitize-blacklist=/home/some/path/blacklist-sgen ...
+...
+CFLAGS = -fsanitize=thread -fsanitize-blacklist=/home/some/path/blacklist-sgen ...
+...
+CFLAGS_FOR_BUILD = -fsanitize=thread -fsanitize-blacklist=/home/some/path/blacklist-sgen ...
+...
+$ make
+```

--- a/docs/debug+profile/clang/customisation.md
+++ b/docs/debug+profile/clang/customisation.md
@@ -1,0 +1,34 @@
+---
+title: Customisation (Clang Sanitizers)
+---
+
+Usually, the default setup of [Clang's sanitizers](https://clang.llvm.org/docs/index.html) is pretty decent. Nonetheless, all of the sanitizers ship with a large amount of options that allow very detailed tuning to support a vast variety of different scenarios. A selection of individual options will be discussed within the articles that are dedicated to the specific sanitizers. The aim of this article is to provide general information about how to apply these options.
+
+To keep things simple, code examples in this article will feature the [ThreadSanitizer](/docs/debug+profile/clang/threadsanitizer/). However, the same concepts and rules apply for all [Clang sanitizers](/docs/debug+profile/clang/) when used in combination with Mono.
+
+Compile Time Options
+--------------------
+
+One group of options have to be applied at compile time when the sanitizers inject functions into the code. Therefore, they have to be set as part of `CFLAGS` that is given to `autogen.sh`. Usually, there is no limit to the number of flags that can be set simultaneously. One example is the [blacklist flag](/docs/debug+profile/clang/blacklists/) that will be used with almost all sanitizers:
+
+``` bash
+$ cd /home/root/of/mono
+$ ./autogen.sh --prefix=/usr/local CC=clang CFLAGS="-fsanitize=thread -fsanitize-blacklist=/home/some/path/blacklist" LDFLAGS=-fsanitize=thread CXX=clang++
+$ make
+...
+```
+
+Runtime Options
+---------------
+
+Runtime options can be set by using environment variables (like `TSAN_OPTIONS`). The name of these variables are different for every sanitizer and will be mentioned in the dedicated articles. For instance, in combination with `make`, they can be applied like so:
+
+``` bash
+$ cd /home/root/of/mono
+$ TSAN_OPTIONS="foo=bar foo2=bar2 foo3=bar3" make
+...
+```
+
+Please be aware that `TSAN_OPTIONS` have to be set every time an annotated program is executed. In the example above, `TSAN_OPTIONS` is only applied to the `make` process and all its sub-processes. When using the compiled and annotated runtime later, `TSAN_OPTIONS` has to be provided again.
+
+Since the runtime options are casual environment variables, all other means of setting them work as well. Have a look at the [official Ubuntu manual](https://help.ubuntu.com/community/EnvironmentVariables), for instance, for more details.

--- a/docs/debug+profile/clang/index.md
+++ b/docs/debug+profile/clang/index.md
@@ -1,7 +1,8 @@
 ---
-title: Clang
+title: Clang Sanitizers
 ---
 
-The Mono runtime can be compiled and linked with [Clang](https://clang.llvm.org/) and therefore, many of [Clang's sanitisers](https://clang.llvm.org/docs/index.html#using-clang-as-a-compiler) can be used to check and verify different aspects:
+The Mono runtime can be compiled and linked with [Clang](https://clang.llvm.org/) and due to this, many of [Clang's sanitizers](https://clang.llvm.org/docs/index.html#using-clang-as-a-compiler) can be used to check and verify different aspects:
 
-- [ThreadSanitizer](/docs/debug+profile/clang/threadsanitizer/) - detect data races at execution time
+- [ThreadSanitizer (TSan)](/docs/debug+profile/clang/threadsanitizer/) - detect data races and thread leaks at runtime
+- [AddressSanitizer (ASan)](/docs/debug+profile/clang/addresssanitizer/) - detect memory errors (mostly buffer over- / underflows) at runtime

--- a/docs/debug+profile/clang/threadsanitizer.md
+++ b/docs/debug+profile/clang/threadsanitizer.md
@@ -13,7 +13,7 @@ $ make
 
 Please keep in mind that `CXX` has to be set to `clang++` to avoid unwanted side effects and compiling errors.
 
-After `autogen.sh` has been executed as suggested above, the following `make` command will use Clang. In turn, Clang then injects necessary reporting functions into the code. Later, `make` uses [roslyn](https://github.com/dotnet/roslyn) to compile  the `mscorelib.dll` with the freshly built Mono runtime. This reports a bit more than 150 races and produces slightly more than 1.5 MB of race traces (`master` branch, August 2017).
+After `autogen.sh` has been executed as suggested above, the following `make` command will use Clang. In turn, Clang then injects necessary reporting functions into the code. Later, `make` uses [roslyn](https://github.com/dotnet/roslyn) to compile  the `mscorlib.dll` with the freshly built Mono runtime. This reports a bit more than 150 races and produces slightly more than 1.5 MB of race traces (`master` branch, August 2017).
 
 Dynamic Blacklisting
 --------------------

--- a/docs/debug+profile/clang/threadsanitizer.md
+++ b/docs/debug+profile/clang/threadsanitizer.md
@@ -1,11 +1,8 @@
 ---
-title: ThreadSanitizer (Clang)
+title: ThreadSanitizer (Clang Sanitizers)
 ---
 
-Using the ThreadSanitizer with Mono
------------------------------------
-
-The [ThreadSanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html) is integrated into Clang 3.4+ and therefore, if Clang is installed, using it with Mono's `autogen.sh` is as simple as running the following:
+The [ThreadSanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html) is integrated into [Clang](https://clang.llvm.org/) 3.4+ and therefore, if Clang is installed, using it with Mono's `autogen.sh` is as simple as running the following:
 
 ``` bash
 $ cd /home/root/of/mono
@@ -14,64 +11,25 @@ $ make
 ...
 ```
 
-Please mind that `CXX` has to be set to `clang++` to avoid unwanted side effects and compiling errors.
+Please keep in mind that `CXX` has to be set to `clang++` to avoid unwanted side effects and compiling errors.
 
-After `autogen.sh` has been executed as suggested above, the following `make` command uses Clang and injects necessary reporting functions. Later, `make` uses [roslyn](https://github.com/dotnet/roslyn) to compile `mcs` with the freshly built Mono runtime. This reports a bit more than 150 races and produces slightly more than 1.5 MB of race traces (`master` branch, July 2017).
+After `autogen.sh` has been executed as suggested above, the following `make` command will use Clang. In turn, Clang then injects necessary reporting functions into the code. Later, `make` uses [roslyn](https://github.com/dotnet/roslyn) to compile  the `mscorelib.dll` with the freshly built Mono runtime. This reports a bit more than 150 races and produces slightly more than 1.5 MB of race traces (`master` branch, August 2017).
 
-Using Blacklists
-----------------
+Dynamic Blacklisting
+--------------------
 
-### Getting started
+Many of these 150 races are harmless - among them are hazard pointers and less important logging counters, to name a few examples. A convenient way to (de)activate the report of specific races quickly is to work with blacklists. Please have a look at [this article](/docs/debug+profile/clang/blacklists/) to find out how to work with blacklists in combination with Mono.
 
-Many of these 150 races are harmless - among them are hazard pointers and less important logging counters, to name a few examples. A convenient way to (de)activate the report of specific races quickly is to work with blacklists. A blacklist file contains the names of source files and/or functions whose races should not be reported. Such blacklist files can be placed anywhere on the system. The simplest approach (an empty blacklist) would look like this:
+Furthermore, the [blacklist](https://github.com/mono/mono/blob/master/scripts/ci/clang-thread-sanitizer-blacklist) in `scripts/ci/` can be a good starting point when exploring Mono with the ThreadSanitizer.
 
-``` bash
-$ touch /home/some/path/blacklist
-$ cd /home/root/of/mono
-$ ./autogen.sh --prefix=/usr/local CC=clang CFLAGS="-fsanitize=thread -fsanitize-blacklist=/home/some/path/blacklist" LDFLAGS=-fsanitize=thread CXX=clang++
-$ make
-...
-```
+Permanent Blacklisting
+----------------------
 
-Currently (July 2017) it seems like a good idea to leave all blacklist files outside of the repository, as sometimes `autogen.sh` treats blacklist files like source files and lists them as dependencies. As an additional, positive side effect, the blacklist files will not interfere with git.
+While blacklist files are handy when it comes to debugging, they are less convenient when looking for solutions that work without the setup process of blacklists. As mentioned above, some data races are known, can be ignored, and will not be fixed. These races should be blacklisted permanently.
 
-The easiest way of blocking everything is to simply put `src:*` into the blacklist file:
+### Function Annotation
 
-``` bash
-$ cat /home/some/path/blacklist
-src:*
-```
-
-However, a finer granularity (toggling the reporting of functions instead of the reporting of whole source files) is often desirable. Currently, at least `fun:` can be used to achieve that. Also, `src:` and `fun:` can be used in the same blacklist file and even the usage of wildcards (`*`) is supported. Please have a look at the [official documentation](https://clang.llvm.org/docs/SanitizerSpecialCaseList.html) for more details.
-
-### Partitioning Blacklists
-
-Changes of blacklist files are detected automatically. The first `make` command after changing a blacklist file recompiles all source files that use that specific blacklist file for compilation. While this is extremely useful, it wastes a lot of CPU and time to recompile the whole project when only debugging / toggling a few functions of a specific module. One way of working with the ThreadSanitizer more efficiently is to partition the blocked functions and source files into dedicated blacklist files. To link those dedicated blacklists to Clang, all corresponding `Makefile` files have to be altered.
-
-For example, if `mono/sgen/` was to be debugged, a setup could look like this:
-
-``` bash
-$ cd /home/root/of/mono
-$ ./autogen.sh --prefix=/usr/local CC=clang CFLAGS="-fsanitize=thread -fsanitize-blacklist=/home/some/path/blacklist" LDFLAGS=-fsanitize=thread CXX=clang++
-$ cat /home/some/path/blacklist-sgen
-fun:sweep_block
-fun:sweep_block_for_size
-$ # alter mono/sgen/Makefile
-$ cat mono/sgen/Makefile
-...
-CCASFLAGS = -fsanitize=thread -fsanitize-blacklist=/home/some/path/blacklist-sgen ...
-...
-CFLAGS = -fsanitize=thread -fsanitize-blacklist=/home/some/path/blacklist-sgen ...
-...
-CFLAGS_FOR_BUILD = -fsanitize=thread -fsanitize-blacklist=/home/some/path/blacklist-sgen ...
-...
-$ make
-```
-
-Permanent Blacklisting (Function Annotation)
---------------------------------------------
-
-While blacklist files are handy when it comes to debugging, they are less convenient when looking for permanent solutions that work without the setup process of blacklists. As mentioned above, some data races are known, can be ignored, and will not be fixed. These races should be blacklisted via function annotation. Functions that are flagged with [`MONO_NO_SANITIZE_THREAD`](https://github.com/mono/mono/blob/master/mono/utils/mono-compiler.h) behave exactly as if their name was found in a blacklist file. If, for example, `foo ()` contains a known race, the following code could be used:
+Functions that are flagged with [`MONO_NO_SANITIZE_THREAD`](https://github.com/mono/mono/blob/master/mono/utils/mono-compiler.h) behave exactly as if their name was found in a blacklist file. If, for example, `foo ()` contains a known race that should be ignored, the following code could be used:
 
 ``` c
 MONO_NO_SANITIZE_THREAD
@@ -82,342 +40,37 @@ foo (void)
 }
 ```
 
-Please mind that these annotations should be used with **great caution**! Many functions contain more than just one data race. Furthermore, other (new) races might arise due to code refactoring but stay hidden if racy functions were annotated before. Therefore, all occurrences of `MONO_NO_SANITIZE_THREAD` should come with meaningful and detailed descriptions of all expected data races.
+Please note that these annotations should be used with **great caution**! Many functions contain more than just one data race. Furthermore, other (new) races might arise due to code refactoring but may stay hidden if racy functions are annotated. Therefore, all occurrences of `MONO_NO_SANITIZE_THREAD` should come with meaningful and detailed descriptions of all expected data races.
 
-Customise the ThreadSanitizer
------------------------------
+### Unlocked Operations
 
-The default setup of the ThreadSanitizer is pretty decent. Nonetheless, there are a some options that can improve certain aspects of working with it.
+Closely related to [`atomic.h`](https://github.com/mono/mono/blob/master/mono/utils/atomic.h), [`unlocked.h`](https://github.com/mono/mono/blob/master/mono/utils/unlocked.h) provides a set of functions that can be used to blacklist simple load / store operations. Unlike `Interlocked* ()` functions, the `Unlocked* ()` functions do not guarantee atomicity but speed: due to inlining, they execute as fast as `x ++`, `x += y`, ... if the ThreadSanitizer is not active. Additionally, the signature of the `Unlocked* ()` functions should always match the signature of the `Interlocked* ()` functions (where interlocked functions exist) to make switching between `Interlocked* ()` and `Unlocked* ()` as easy as possible.
 
-### Compiler Options
+Compile Time Options
+--------------------
 
-Clang's ThreadSanitizer supports a lot of [compiler options](https://github.com/google/sanitizers/wiki/ThreadSanitizerFlags#compiler-flags-llvm-specific) that should be provided via `CFLAGS` when running `autogen.sh`. One of these options proves to be extremely useful:
+The ThreadSanitizer can be personalised in many ways. [This article](/docs/debug+profile/clang/customisation/#runtime-options) describes in detail how compile time options can be used in combination with Mono. In addition, all available flags can be found on [Google's GitHub page](https://github.com/google/sanitizers/wiki/ThreadSanitizerFlags#compiler-flags-llvm-specific). There is one especially useful option:
 
-#### (Stop) The Instrumentation of Atomic Operations
+### (Stop) The Instrumentation of Atomic Operations
 
-[atomic.h](https://github.com/mono/mono/blob/master/mono/utils/atomic.h) in `mono/utils/` containts atomic functions that are mostly harmless; however, they are rightfully detected as data races. Some examples are `InterlockedCompareExchange`, `InterlockedIncrement` or `InterlockedExchangePointer`. If all atomic instructions should be blacklisted at once, the easiest and cleanest solution is to add `-mllvm -tsan-instrument-atomics=false` to the `CFLAGS` argument of `autogen.sh`. Using it together with a blacklist could look like this:
+[atomic.h](https://github.com/mono/mono/blob/master/mono/utils/atomic.h) in `mono/utils/` contains atomic functions that are mostly harmless; however, they are rightfully detected as data races. Some examples are `InterlockedCompareExchange`, `InterlockedIncrement` or `InterlockedExchangePointer`. If all atomic instructions should be blacklisted at once, the easiest and cleanest solution is to use `-mllvm -tsan-instrument-atomics=false`.
 
-``` bash
-$ cd /home/root/of/mono
-$ ./autogen.sh --prefix=/usr/local CC=clang CFLAGS="-fsanitize=thread -fsanitize-blacklist=/home/some/path/blacklist -mllvm -tsan-instrument-atomics=false" LDFLAGS=-fsanitize=thread CXX=clang++
-$ make
-...
-```
+Runtime Options
+---------------
 
-### Runtime Options
+Runtime options can be provided by using the environment variable `TSAN_OPTIONS`. Please find detailed information about runtime options and Mono in [this article](/docs/debug+profile/clang/customisation/#runtime-options) and all available options on [Google's GitHub page](https://github.com/google/sanitizers/wiki/ThreadSanitizerFlags#runtime-flags). Two runtime flags in particular seem to be useful when working with Mono:
 
-Clang's ThreadSanitizer also supports various [runtime options](https://github.com/google/sanitizers/wiki/ThreadSanitizerFlags). In combination with `make`, they can be applied like so:
+### Increase the Memory Access History
 
-``` bash
-$ cd /home/root/of/mono
-$ TSAN_OPTIONS="foo=bar foo2=bar2 foo3=bar3" make
-...
-```
+Sometimes, races extend over a long period of time; however, they might not be harmless. By default, the ThreadSanitizer only remembers the last two memory accesses per thread which can lead to incomplete stack traces that are hard (or impossible) to comprehend. Using `history_size=7` (`7` is the maximum size) often seems to help with resolving this issue.
 
-Please be aware that the runtime options have to be set everytime a ThreadSanitizer-annotated program is used. `TSAN_OPTIONS` is only applied to the `make` process in the example code above. When using `mono` later, `TSAN_OPTIONS` has to be provided again.
+### Exit with 0
 
-Two runtime flags in particular seem to be useful when working with Mono:
-
-#### Increase the Memory Access History
-
-Sometimes, races extend over a long period of time; however, they might not be harmless. By default, only the last two memory accesses get remembered per thread. This can lead to incomplete stack traces that are hard (or impossible) to comprehend. To avoid this, the runtime flag `history_size=4` seems to be a good trade-off between memory consumption and complete stack traces.
-
-#### Exit with 0
-
-By default, the ThreadSanitizer exits with `66` whenever at least one race was detected. This can be inconvenient, when compiling a batch of files. Luckily, the runtime option `exitcode=0` (or `1`, `2`, ...) can help with that.
+By default, the ThreadSanitizer exits with `66` whenever at least one race or leak was detected. This can be inconvenient, when compiling a batch of files. Luckily, the runtime option `exitcode=0` (or `1`, `2`, ...) can help with that.
 
 Additional Information
 ----------------------
 
 ### Evaluation
 
-Clang's ThreadSanitizer is currently in a try-out phase (July 2017). Many races are being evaluated and are either about to be blacklisted and documented, or reported and fixed. Due to this, updates of this page will happen frequently.
-
-### A List of Functions
-
-As of July 2017, blacklisting the following functions should hide most data race warnings (this list can be copy-and-pasted into a blacklist file):
-
-``` bash
-# ------------------------------------------------------------ #
-#   eglib/src
-# ------------------------------------------------------------ #
-
-fun:monoeg_g_hash_table_iter_next
-
-# ------------------------------------------------------------ #
-#   mono/metadata
-# ------------------------------------------------------------ #
-
-# class.c #
-
-fun:make_generic_param_class
-fun:mono_class_create_from_typedef
-fun:mono_class_from_generic_parameter_internal
-fun:mono_class_get_methods
-fun:mono_class_has_failure
-fun:mono_class_has_finalizer
-fun:mono_class_inflate_generic_method_full_checked
-fun:mono_class_inflate_generic_type_no_copy
-fun:mono_class_inflate_generic_type_with_mempool
-fun:mono_class_init
-fun:mono_class_setup_fields
-fun:mono_class_setup_methods
-fun:mono_class_setup_vtable_full
-fun:mono_class_setup_vtable_general
-fun:mono_generic_class_get_class
-fun:mono_method_get_context_general
-
-# class-accessors.c #
-
-fun:mono_class_get_flags
-fun:mono_class_get_method_count
-fun:mono_class_set_method_count
-
-# class-inlines.h #
-
-fun:mono_class_is_ginst
-fun:mono_class_is_gtd
-
-# domain.c #
-
-fun:mono_domain_alloc0
-
-# gc.c #
-
-fun:finalize_domain_objects
-fun:finalizer_thread
-fun:mono_domain_finalize
-fun:mono_gc_cleanup
-
-# icall.c #
-
-fun:ves_icall_System_Reflection_MonoMethodInfo_get_parameter_info
-fun:ves_icall_RuntimeType_GetConstructors_native
-
-# image.c #
-
-fun:mono_image_alloc
-fun:mono_image_alloc0
-fun:mono_image_strdup
-
-# jit-info.c #
-
-fun:jit_info_table_add
-fun:jit_info_table_chunk_index
-fun:jit_info_table_find
-fun:jit_info_table_index
-fun:mono_jit_compile_method_with_opt
-fun:mono_jit_info_init
-fun:mono_jit_info_table_find_internal
-
-# loader.c #
-
-fun:cache_memberref_sig
-fun:mon_new
-fun:mono_get_method_from_token
-fun:mono_method_get_signature_checked
-fun:mono_method_signature_checked
-
-# marshal.c #
-
-fun:mono_marshal_get_native_wrapper
-fun:mono_marshal_isinst_with_cache
-
-# metadata.c #
-
-fun:img_set_cache_get
-fun:_mono_metadata_generic_class_equal
-fun:mono_metadata_get_canonical_generic_inst
-fun:mono_metadata_lookup_generic_class
-fun:mono_type_get_type
-
-# monitor.c #
-
-fun:mono_monitor_ensure_owned
-fun:mono_monitor_exit_inflated
-fun:mono_monitor_try_enter_inflated
-fun:mono_object_hash
-fun:ves_icall_System_Threading_Monitor_Monitor_pulse_all
-fun:ves_icall_System_Threading_Monitor_Monitor_test_synchronised
-fun:ves_icall_System_Threading_Monitor_Monitor_wait
-
-# mono-conc-hash.c #
-
-fun:mono_conc_g_hash_table_lookup_extended
-fun:set_key
-
-# mono-hash.c #
-
-fun:mono_g_hash_table_max_chain_length
-
-# object.c #
-
-fun:mono_class_compute_gc_descriptor
-fun:mono_class_create_runtime_vtable
-fun:mono_class_vtable_full
-fun:mono_delegate_ctor_with_method
-fun:mono_runtime_class_init_full
-
-# reflection.c #
-
-fun:method_object_construct
-fun:reflected_equal
-
-# reflection-cache.h #
-
-fun:cache_object_handle
-
-# runtime.c #
-
-fun:mono_runtime_is_shutting_down
-fun:mono_runtime_try_shutdown
-
-# sgen-mono.c #
-
-fun:mono_gc_wbarrier_set_arrayref
-fun:sgen_client_gchandle_created
-fun:sgen_client_gchandle_destroyed
-
-# threadpool.c #
-
-fun:worker_callback
-
-# threadpool-worker-default.c #
-
-fun:heuristic_adjust
-fun:heuristic_notify_work_completed
-fun:heuristic_should_adjust
-fun:hill_climbing_update
-fun:monitor_should_keep_running
-fun:monitor_thread
-
-# threads.c #
-
-fun:build_wait_tids
-fun:create_thread
-fun:mono_thread_clr_state
-fun:mono_thread_detach_internal
-fun:mono_threads_add_joinable_thread
-fun:mono_threads_join_threads
-fun:remove_and_abort_threads
-
-# w32handle.c #
-
-fun:mono_w32handle_init_handle
-fun:mono_w32handle_lookup_data
-fun:mono_w32handle_unref_core
-
-# ------------------------------------------------------------ #
-#   mono/mini
-# ------------------------------------------------------------ #
-
-# alias-analysis.c #
-
-fun:recompute_aliased_variables
-
-# mini.c #
-
-fun:mini_method_compile
-fun:mono_allocate_stack_slots
-fun:mono_jit_compile_method_inner
-fun:mono_save_seq_point_info
-fun:mono_time_track_end
-fun:mono_type_to_load_membase
-
-# mini-generic-sharing.c #
-
-fun:mini_get_basic_type_from_generic
-fun:mini_is_gsharedvt_type
-fun:mono_generic_context_check_used
-fun:mono_method_check_context_used
-
-# mini-native-types.c #
-
-fun:mini_native_type_replace_type
-
-# mini-runtime.c #
-
-fun:mono_jit_find_compiled_method_with_jit_info
-
-# mini-trampolines.c #
-
-fun:common_call_trampoline
-fun:mini_resolve_imt_method
-fun:mono_create_jit_trampoline
-fun:mono_delegate_trampoline
-fun:mono_magic_trampoline
-fun:mono_rgctx_lazy_fetch_trampoline
-fun:mono_vcall_trampoline
-
-# ------------------------------------------------------------ #
-#   mono/sgen
-# ------------------------------------------------------------ #
-
-# sgen-array-list.h #
-
-fun:sgen_array_list_bucketize
-
-# sgen-array-list.c #
-
-fun:sgen_array_list_add
-fun:sgen_array_list_find_unset
-
-# sgen-fin-weak-hash.c #
-
-fun:add_stage_entry
-
-# sgen-gc.h #
-
-fun:sgen_set_nursery_scan_start
-
-# sgen-gc #
-
-fun:mono_gc_wbarrier_generic_store
-
-# sgen-gchandles.c #
-
-fun:is_slot_set
-fun:link_get
-fun:mono_gchandle_free
-fun:sgen_gchandle_iterate
-
-# sgen-marksweep.c #
-
-fun:ensure_block_is_checked_for_sweeping
-fun:major_finish_sweep_checking
-fun:set_block_state
-fun:sweep_block
-fun:sweep_block_for_size
-fun:unlink_slot_from_free_list_uncontested
-
-# ------------------------------------------------------------ #
-#   mono/utils
-# ------------------------------------------------------------ #
-
-# hazard-pointer.c #
-
-fun:is_pointer_hazardous
-fun:mono_get_hazardous_pointer
-
-# memfuncs.c #
-
-fun:mono_gc_memmove_aligned
-
-# mono-conc-hashtable.c #
-
-fun:mono_conc_hashtable_lookup
-
-# mono-lazy-init.h #
-
-fun:mono_lazy_initialize
-
-# mono-threads-posix-signals.c #
-
-fun:restart_signal_handler
-fun:suspend_signal_handler
-
-# mono-threads-state-machine.c #
-
-fun:check_thread_state
-fun:mono_threads_transition_finish_async_suspend
-```
+Clang's ThreadSanitizer is currently in a try-out phase (August 2017). Many races are being evaluated and are either about to be blacklisted and documented, or reported and fixed. Due to this, updates of this page will happen frequently.

--- a/docs/debug+profile/index.md
+++ b/docs/debug+profile/index.md
@@ -4,4 +4,4 @@ title: Debug and Profile
 
 - [Debug](/docs/debug+profile/debug/)
 - [Profile](/docs/debug+profile/profile/)
-- [Clang](/docs/debug+profile/clang/)
+- [Clang Sanitizers](/docs/debug+profile/clang/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,9 +105,10 @@ Our website is open source on [GitHub](https://github.com/mono/website). If you 
                         <li><a href="/docs/debug+profile/profile/code-coverage/">Code Coverage</a></li>
                     </ul>
                 </li>
-                <li><a href="/docs/debug+profile/clang/">Clang - Overview</a>
+                <li><a href="/docs/debug+profile/clang/">Clang Sanitizers - Overview</a>
                     <ul>
-                        <li><a href="/docs/debug+profile/clang/threadsanitizer/">ThreadSanitizer</a></li>
+                        <li><a href="/docs/debug+profile/clang/threadsanitizer/">ThreadSanitizer (TSan)</a></li>
+                        <li><a href="/docs/debug+profile/clang/addresssanitizer/">AddressSanitizer (ASan)</a></li>
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
- add an article about ASan
- add information about the `Unlocked* ()` functions to the TSan article
- put the information about blacklists and flags into separate articles
- improve the general structure of the Clang sanitisers documentation