### PR TITLE
fixed hyperlink for "Community Promise"

### DIFF
--- a/docs/about-mono/languages/index.md
+++ b/docs/about-mono/languages/index.md
@@ -16,7 +16,7 @@ C#
 
 The main C# compiler of the Mono Project is [**mcs**](/docs/about-mono/languages/csharp/). It covers all the features in C# 3.0 (2.6), 4.0, 5.0 and 6.0, including 3.0 LINQ, 4.0 dynamic and 5.0 async-await support.
 
-C# is specified in the ISO/IEC 23271:2006 and ECMA 334 standards. Microsoft has [granted access to their patents](http://port25.technet.com/archive/2009/07/06/the-ecma-c-and-cli-standards.aspx) under their [Community Promise](http://www.microsoft.com/interop/cp/default.mspx).
+C# is specified in the ISO/IEC 23271:2006 and ECMA 334 standards. Microsoft has [granted access to their patents](http://port25.technet.com/archive/2009/07/06/the-ecma-c-and-cli-standards.aspx) under their [Community Promise](https://msdn.microsoft.com/en-us/openspecifications/dn750984/).
 
 F#
 ---


### PR DESCRIPTION
Note: I didn't linked directly to the community promise page. So you can choose between "Open Specification Promise" and "Community Promise"