### PR TITLE
Update the articles about Clang's sanitisers

### DIFF
--- a/community/google-summer-of-code/reports/2017/corefx-System.IO.Pipes.md
+++ b/community/google-summer-of-code/reports/2017/corefx-System.IO.Pipes.md
@@ -7,6 +7,7 @@ Author: Georgios Athanasopoulos
 This is a report for my contribution to [Mono Project](http://www.mono-project.com/) as Google Summer of Code 2017 student
 
 # Description
+
 Mono is a open source development platform based on the `.Net Framework` and allows developers to build cross-platform applications. Mono's .NET implementation is based on the ECMA standards for `C#` and the `Common Language Infrastructure`. It includes both developer tools and the infrastructure needed to run .NET client and server applications on `Linux, Microsoft Windows, Mac OS X, BSD, Sun Solaris, Nintendo Wii, Sony PlayStation 3, Apple iPhone and Android`.
 
 Mono is supported by Microsoft and .Net Foundation and consisted by:
@@ -16,9 +17,11 @@ Mono is supported by Microsoft and .Net Foundation and consisted by:
 * `Mono Class Library`
 
 # Goal
+
 The implementation of Pipe Streams in `Mono` doesn't support some functionalities such as parallel builds on msbuild. `CoreFX` is the foundational libraries for .NET Core. The implementation of Pipe Streams in CoreFx fixes the previous problems. So, the goal of the project was to import `System.IO.Pipes.PipeStream` from CoreFX to Mono. Doing this, new features are offered by Mono.
 
 # Work process
+
 Initially, I learned more about Mono Project and explored platform structure. Mono Project in order to manage running at different platforms, has implemented layer abstraction. There are source files (with .dll.sources extension) which are responsible for building of libraries. In these files are included source files of classes that will integrate every library. For example I worked on System.Core library that contains LINQ To Objects implementation and the classes HashSet, TimeZoneInfo, Pipes, ReaderWriteLockSlim, System.Security.*, System.Diagnostics.Eventing.* and System.Diagnostics.PerformanceData. For this library, there is the `common_System.Core.dll.sources` file in which independent classes from platforms or profiles, are included. One of profile specific files is the `net_4_x_System.Core.dll.sources`. This file import common classes from `common_System.Core.dll.sources` and additional classes that are required by net_4_x profile. Similarly the `win32_net_4_x_System.Core.dll.sources` file is windows platform specific and import classes from `net_4_x_System.Core.dll.sources` and additional classes that are required by windows platform. The schema of this structure is presented at Figure 1.
 
 |[![gsoc-2017-corefx-System.IO.Pipes.png](/images/gsoc-2017-corefx-System.IO.Pipes.png)](/images/gsoc-2017-corefx-System.IO.Pipes.png)|
@@ -27,17 +30,16 @@ Initially, I learned more about Mono Project and explored platform structure. Mo
 
 Some other profile specific files are `monodroid_System.Core.dll.sources`, `monotouch_System.Core.dll.sources`, `monotouch_runtime_System.Core.dll.sources`, `monotouch_watch_System.Core.dll.sources`, `monotouch_watch_runtime_System`, `monotouch_tv_System.Core.dll.sources`, `monotouch_tv_runtime_System.Core.dll.sources`, `testing_aot_hybrid_System.Core.dll.sources`, `testing_full_hybrid_System.Core.dll.sources`, `winaot_System.Core.dll.sources`, `xammac_System.Core.dll.sources`, `xammac_net_4_5_System.Core.dll.sources`, `orbis_System.Core.dll.sources`.
 
-Some other platform specific files are `win32_basic_System.Core.dll.sources`, `win32_build_System.Core.dll.sources`, `win32_net_4_x_System.Core.dll.sources`, `linux_basic_System.Core.dll.sources`, `linux_build_System.Core.dll.sources`, `linux_net_4_x_System.Core.dll.sources`, `darwin_basic_System.Core.dll.sources`, `darwin_build_System.Core.dll.sources`, `darwin_net_4_x_System.Core.dll.sources`. 
+Some other platform specific files are `win32_basic_System.Core.dll.sources`, `win32_build_System.Core.dll.sources`, `win32_net_4_x_System.Core.dll.sources`, `linux_basic_System.Core.dll.sources`, `linux_build_System.Core.dll.sources`, `linux_net_4_x_System.Core.dll.sources`, `darwin_basic_System.Core.dll.sources`, `darwin_build_System.Core.dll.sources`, `darwin_net_4_x_System.Core.dll.sources`.
 
 I should have imported from CoreFx the files that are in [this](https://github.com/dotnet/corefx/blob/master/src/System.IO.Pipes/src/System.IO.Pipes.csproj) csproj file. A `.csproj` file contains a list of all the files to be compiled as part of a project, as well as other options like the project name, release and debug configurations and compilation options. In `System.IO.Pipes.csproj`, I found the files that are compiled when the project is building. Because they are the files that constitute Pipes in corefx, should be transfered in mono. Csproj files have two ways for referring in compiled files. The explicit way in which every file being compiled and conditional way in which a file being compiled only if a condition is true. So, I found files that are compiled only when the platform is either Windows or Unix and files that are compiled at any case. On the first occasion, I added these files in `win32_net_4_x_System.Core.dll.sources`, `linux_net_4_x_System.Core.dll.sources` and `darwin_System.Core.dll.sources` regarding to platform, while on the second I added files in `common_System.Core.dll.sources` because should be compiled at every platform.
 The import of CoreFx code was easy because the code existed as submodule in repo. Also, I added some errors messages in `SR.cs` file that are existed now due to new CoreFx code.
 
-When I resolved some duplicated references between Mono and CoreFx code, built mono with my changes. Running tests, I found out that some APIs of Mono were dropped by CoreFx. In particular, mono has this function `NamedPipeServerStream(String pipeName, PipeDirection direction, int maxNumberOfServerInstances, PipeTransmissionMode transmissionMode, PipeOptions options, int inBufferSize, int outBufferSize,PipeSecurity pipeSecurity, HandleInheritability inheritability,  PipeAccessRights additionalAccessRights)` while in corefx implementation there is `NamedPipeServerStream(String pipeName, PipeDirection direction, int maxNumberOfServerInstances, PipeTransmissionMode transmissionMode, PipeOptions options, int inBufferSize, int outBufferSize, HandleInheritability inheritability)`. Mono's version has two more arguments, PipeSecurity pipeSecurity and PipeAccessRights additionalAccessRights. So, I had to change CoreFx code in order to support the broken APIs of Mono. First I added the missing arguments in corefx's NamedPipeServerStream and I put default values where NamedPipeServerStream was called. Also, in NamedPipeServerStream there was a call of `Create` which is used for creation of a pipe on a specific platform. I put the two additional arguments in Create as well. In Create of Windows platform, I added additionalAccessRights at openMode variable and pipeSecurity in GetSecAttrs, implementing the same functionality as mono's version. 
+When I resolved some duplicated references between Mono and CoreFx code, built mono with my changes. Running tests, I found out that some APIs of Mono were dropped by CoreFx. In particular, mono has this function `NamedPipeServerStream(String pipeName, PipeDirection direction, int maxNumberOfServerInstances, PipeTransmissionMode transmissionMode, PipeOptions options, int inBufferSize, int outBufferSize,PipeSecurity pipeSecurity, HandleInheritability inheritability,  PipeAccessRights additionalAccessRights)` while in corefx implementation there is `NamedPipeServerStream(String pipeName, PipeDirection direction, int maxNumberOfServerInstances, PipeTransmissionMode transmissionMode, PipeOptions options, int inBufferSize, int outBufferSize, HandleInheritability inheritability)`. Mono's version has two more arguments, PipeSecurity pipeSecurity and PipeAccessRights additionalAccessRights. So, I had to change CoreFx code in order to support the broken APIs of Mono. First I added the missing arguments in corefx's NamedPipeServerStream and I put default values where NamedPipeServerStream was called. Also, in NamedPipeServerStream there was a call of `Create` which is used for creation of a pipe on a specific platform. I put the two additional arguments in Create as well. In Create of Windows platform, I added additionalAccessRights at openMode variable and pipeSecurity in GetSecAttrs, implementing the same functionality as mono's version.
 
 Afterwards, I imported `System.IO.Pipes.PipeStream` from CoreFx to build and basic profile with similar way as before. I built and run tests on Windows and Linux platform. The results of tests were successful. For macOS platform, I couldn't build and run tests because didn't have a machine.
 
-Beacause I couldn't test all profiles, some includes from previous version of `common_System.Core.dll.sources` had to stay there. It 	
-caused conflicts with the includes from corefx. The solution was to transfer these files to the layer of profile specific files ( e.g `monodroid_System.Core.dll.sources`, `net_4_x_System.Core.dll.sources`). So, the profiles which I couln't test have the previous includes of mono, but the other have corefx includes.
+Beacause I couldn't test all profiles, some includes from previous version of `common_System.Core.dll.sources` had to stay there. It caused conflicts with the includes from corefx. The solution was to transfer these files to the layer of profile specific files ( e.g `monodroid_System.Core.dll.sources`, `net_4_x_System.Core.dll.sources`). So, the profiles which I couln't test have the previous includes of mono, but the other have corefx includes.
 
 Also, I tried to import my changes to `testing_aot_full` and `testing_aot_hybrid` profile which are relative to Ahead Of Time Compiler of Mono. But there was crash in the runtime in stable version of Mono, so it prevented me from testing.
 About `monotouch` and `monodroid` profiles, I couldn't test them because it was very hard to test on Android and IOS environment.
@@ -66,21 +68,22 @@ Here, are the profiles that aren't tested:
 * xammac_net_4_5
 * orbis
 
-
 At the end, I enabled signing of libraries for security reasons.
 
 Here are the commits that I did in Mono and CoreFx repos:
 * [Mono](https://github.com/Geotha/mono/commits/gsoc-System.IO.Pipes?author=geotha)
-* [CoreFx](https://github.com/Geotha/corefx/commits/gsoc-System.IO.Pipes?author=geotha) 
+* [CoreFx](https://github.com/Geotha/corefx/commits/gsoc-System.IO.Pipes?author=geotha)
 
 # Extra Work
+
 In addition to proposed work, I undertook to run [`msbuild`](https://msdn.microsoft.com/en-us/library/dd393574.aspx) with parallel builds enabled on Linux using mono. Before my changes, parallel builds weren't possible. So, the purpose was to check if this important feature will work with CoreFx implementation. Running tests on msbuild with mono and without parallel builds enabled, I took errors both stable and my version of mono. Enabling parallel builds, errors were remaining and I couldn't determine if my version works properly.
 
-
 # Future work
+
 * Test CoreFx implementation to `testing_aot_full` and `testing_aot_hybrid` profiles, when runtime crash is resolved.
 * Test CoreFx implementation to `monotouch` and `monodroid` profiles, when there is suitable equipment.
 * Test mono on msbuild with `parallel builds` enabled, when tests will run successfully.
 
 # Acknowledgement
+
 Finally, I would like to thank my mentor **Ludovic Henry** for guidance, immense support and excellent collaboration that we had.

--- a/community/google-summer-of-code/reports/2017/cscache-report.md
+++ b/community/google-summer-of-code/reports/2017/cscache-report.md
@@ -5,6 +5,7 @@ title: "CSCache / Mono cache tool (Calancea Daniel)"
 Author:  [Calancea Daniel](https://github.com/dcalance)
 
 ### 1.Introduction
+
 A friend of mine told me about this interesting event, google summer of code. Of course I've heard about it before but I wasn't sure how you can apply or what you need to do. He told me that there are a lot of interesting projects. I took a look
 at the companies and projects and there were a lot of projects, most of them very advanced. At university I was doing my laboratories mostly in C#, since it's pretty easy and Visual Studio is pretty powerful as an IDE.
 The most interesting thing is that when my friend told me about GSOC there were only 2 days left to apply. I applied to 3 projects from mono-project, but mostly wanted to work on the one with the cache tool, the one I was assigned to later.
@@ -12,7 +13,7 @@ Honestly, I had very little idea about how a compiler works, but I knew more or 
 
 At first, it was pretty hard because I had no idea where to start but with help from my mentor and after reading documentation I started to understand what I need to do.
 
-The hardest part was to make the first working program that would cache, store binaries and execute the compiler command. 
+The hardest part was to make the first working program that would cache, store binaries and execute the compiler command.
 
 At the end of the project I learned a lot of things that I'm more than sure will help me in the future. This was an interesting experience and I would gladly apply for GSOC at mono next year aswell.
 
@@ -21,7 +22,7 @@ This year at GSOC I applied to make a similar tool as ccache, but for mono. I wo
 - Where are the unit tests made in MSTest (UnitTests)
 - Where is the nuget package. (NugetPackage)
 
-Link to the repository: https://github.com/dcalance/GSOC17
+Link to the repository: [https://github.com/dcalance/GSOC17](https://github.com/dcalance/GSOC17)
 
 The tool had to have the following features:
 - Able to prevent repeated compilation of a program.
@@ -53,6 +54,7 @@ The process of making the project was the following:
 9. Creating install files for windows and linux.
 
 ### 2.Implementation
+
 The tool is a class library that has a bunch of classes:
 - CSCache - is the main class that recieves the compiler with arguments in constructor and has a method `void Cache()` that caches the input arguments if there is no error.
 - Config - class that handles the config. It generates config if it doesn't exist and stores the values read from config file in properties.
@@ -66,6 +68,7 @@ The tool is minimalistic since the main objective is to be integrated in bigger 
 The classes that are with static members can be reused, that was the main propouse to make them static and public. For example:
 
 #### ConsoleTools.cs
+
 Contains the class ConsoleTools with the following methods and fields:
 - `static bool IsUnix` - This field can determine if your OS is either unix or windows.
 - `static string Execute(string cmdLine, out int errCode)` - This method allows execution of a command either in bash or cmd. The execution is based on the enviromnent from where the application was executed.
@@ -77,12 +80,14 @@ Contains the class ConsoleTools with the following methods and fields:
     - **int errCode** - Exit code of the application.
 
 #### FilesTools.cs
+
 Contains the class FilesTools and methods to work with files:
 - `static string[] GetRecurseFiles(string pattern)` - Gets all files that are fitting the current pattern.
     - **string pattern** - pattern that will be evaluated.
     - **return** - an array of all the files found that correspond to the pattern.
 
 #### MD5Tools.cs
+
 Contains the class MD5Tools and methods for hashing:
 - `static byte[] GenerateFilesCache(List<string> inputF)` - Generates a single MD5 hash from all the input files. Uses the following methods from the same class : **static byte[] MakeMD5File(string filename)**, **static byte[] CombineHashes(List<byte[]> input)**.
     - **List<string> inputF** - a list of input files location. The method throws unhandled error if the file does not exist.
@@ -98,6 +103,7 @@ Contains the class MD5Tools and methods for hashing:
     - **return** - a byte array that is the result of hashing the contents of the file.
 
 #### ParseTools.cs
+
 Contains the class ParseTools with methods for parsing:
 - `static string[] ParseArguments(string commandLine)` - parses the input string as a command line argument.
     - **string commandLine** - the input string that will be parsed.
@@ -116,7 +122,9 @@ Contains the class ParseTools with methods for parsing:
     - **return** - array of strings with parsed elements.
 
 ### 3.Bugs
+
 There is a bug regarding windows bash that I wasn't able to fix. The problem with it appears when you try to create a windows bash process and pass it a compiler line with arguments. The bug is that the paths that have dashes (example: folder1\input1.cs) does not have dashes anymore and compiler throws error that input files is not found. The problem is not at my level of implementation but either at process class or in the way the windows bash processes the input arguments. This bug may appear at random times.
 
 ### 4.Conclusion
+
 This project was an interesting experience for me since it was entirely new, I've never worked at compiler level. Now I can understand more things about how compilers work, how arguments are passed and processed, how the output is generated. This project was great for learning because it was not very difficult and at the same time it had specific things that you can learn from it. The mentor was amazing and helped me in difficult situation at the same time leaving the entire thought process to me.

--- a/docs/debug+profile/clang/addresssanitizer.md
+++ b/docs/debug+profile/clang/addresssanitizer.md
@@ -6,12 +6,12 @@ The [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) is int
 
 ``` bash
 $ cd /home/root/of/mono
-$ ./autogen.sh --prefix=/usr/local CC=clang CFLAGS=-fsanitize=address LDFLAGS=-fsanitize=address CXX=clang++
+$ ./autogen.sh --prefix=/usr/local CC=clang CFLAGS=-fsanitize=address LDFLAGS=-fsanitize=address CXX=clang
 $ make
 ...
 ```
 
-Please keep in mind that `CXX` has to be set to `clang++` to avoid unwanted side effects and compiling errors.
+Please keep in mind that `CXX` has to be set to `clang` to avoid unwanted side effects and compiling errors.
 
 After `autogen.sh` has been executed as suggested above, the following `make` command uses Clang and injects necessary reporting functions.
 

--- a/docs/debug+profile/clang/blacklists.md
+++ b/docs/debug+profile/clang/blacklists.md
@@ -9,7 +9,7 @@ The simplest approach (an empty blacklist) would look like this:
 ``` bash
 $ touch /home/some/path/blacklist
 $ cd /home/root/of/mono
-$ ./autogen.sh --prefix=/usr/local CC=clang CFLAGS="-fsanitize=thread -fsanitize-blacklist=/home/some/path/blacklist" LDFLAGS=-fsanitize=thread CXX=clang++
+$ ./autogen.sh --prefix=/usr/local CC=clang CFLAGS="-fsanitize=thread -fsanitize-blacklist=/home/some/path/blacklist" LDFLAGS=-fsanitize=thread CXX=clang
 $ make
 ...
 ```
@@ -45,7 +45,7 @@ For example, if `mono/sgen/` was to be debugged, a setup could look like this:
 
 ``` bash
 $ cd /home/root/of/mono
-$ ./autogen.sh --prefix=/usr/local CC=clang CFLAGS="-fsanitize=thread -fsanitize-blacklist=/home/some/path/blacklist" LDFLAGS=-fsanitize=thread CXX=clang++
+$ ./autogen.sh --prefix=/usr/local CC=clang CFLAGS="-fsanitize=thread -fsanitize-blacklist=/home/some/path/blacklist" LDFLAGS=-fsanitize=thread CXX=clang
 $ cat /home/some/path/blacklist-sgen
 fun:sweep_block
 fun:sweep_block_for_size

--- a/docs/debug+profile/clang/customisation.md
+++ b/docs/debug+profile/clang/customisation.md
@@ -13,7 +13,7 @@ One group of options have to be applied at compile time when the sanitizers inje
 
 ``` bash
 $ cd /home/root/of/mono
-$ ./autogen.sh --prefix=/usr/local CC=clang CFLAGS="-fsanitize=thread -fsanitize-blacklist=/home/some/path/blacklist" LDFLAGS=-fsanitize=thread CXX=clang++
+$ ./autogen.sh --prefix=/usr/local CC=clang CFLAGS="-fsanitize=thread -fsanitize-blacklist=/home/some/path/blacklist" LDFLAGS=-fsanitize=thread CXX=clang
 $ make
 ...
 ```

--- a/docs/debug+profile/clang/threadsanitizer.md
+++ b/docs/debug+profile/clang/threadsanitizer.md
@@ -6,12 +6,12 @@ The [ThreadSanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html) is integ
 
 ``` bash
 $ cd /home/root/of/mono
-$ ./autogen.sh --prefix=/usr/local CC=clang CFLAGS=-fsanitize=thread LDFLAGS=-fsanitize=thread CXX=clang++
+$ ./autogen.sh --prefix=/usr/local CC=clang CFLAGS=-fsanitize=thread LDFLAGS=-fsanitize=thread CXX=clang
 $ make
 ...
 ```
 
-Please keep in mind that `CXX` has to be set to `clang++` to avoid unwanted side effects and compiling errors.
+Please keep in mind that `CXX` has to be set to `clang` to avoid unwanted side effects and compiling errors.
 
 After `autogen.sh` has been executed as suggested above, the following `make` command will use Clang. In turn, Clang then injects necessary reporting functions into the code. Later, `make` uses [roslyn](https://github.com/dotnet/roslyn) to compile  the `mscorlib.dll` with the freshly built Mono runtime. This reports a bit more than 150 races and produces slightly more than 1.5 MB of race traces (`master` branch, August 2017).
 


### PR DESCRIPTION
No need to use `clang++` explicitly, `CXX=clang` works just as fine.