### PR TITLE
Revert "Update link to benchmarker frontend"

### DIFF
--- a/docs/advanced/garbage-collector/benchmark-suite.md
+++ b/docs/advanced/garbage-collector/benchmark-suite.md
@@ -4,6 +4,6 @@ redirect_from:
   - /Benchmark_Suite/
 ---
 
-The [Mono benchmark suite](http://open.xamarin.com/benchmarker/front-end/) is a set of benchmarks that is run by CI against newly built revisions. The data thereby gathered is then put into visual form, so as to be quickly comprehensible.
+The [Mono benchmark suite](http://xamarin.github.io/benchmarker/front-end/) is a set of benchmarks that is run by CI against newly built revisions. The data thereby gathered is then put into visual form, so as to be quickly comprehensible.
 
 The source of the benchmark suite and frontend is [available](https://github.com/xamarin/benchmarker).


### PR DESCRIPTION
This reverts commit b34d240f6c32975ff4f9a2c13fcea41e0ea43f61.

open.xamarin.com forces redirects to https, which doesn't work with the
benchmarker front-end...