### PR TITLE
Update MonoError documentation

### DIFF
--- a/docs/advanced/runtime/docs/mono-error.md
+++ b/docs/advanced/runtime/docs/mono-error.md
@@ -41,7 +41,6 @@ are not supported to be able to produce them - such use case has yet to arise.
 void*
 my_function (int a, MonoError *error)
 {
-    mono_error_init (error);
     if (a <= 0) {//
         mono_error_set_argument (error, "a", "argument a must be bigger than zero, it was %d", a);
         return NULL;
@@ -53,7 +52,6 @@ my_function (int a, MonoError *error)
 Important points from the above:
 
 - Add a "MonoError *error" argument as the last to your function
-- Call "mono_error_init (error)" unconditionally at the beginning
 - Call one of the mono_error_set functions based on what managed exception this should produce and the available information
 - Document that a NULL returns means an error
 
@@ -64,33 +62,34 @@ Writing a function that consumes errors
 void
 other_function (void)
 {
-    MonoError error;
+    ERROR_DECL (error);
     void *res;
 
-    res = my_function (10, &error);
+    res = my_function (10, error);
     //handling the error:
     //1st option: set the pending exception.  Only safe to do in icalls
-    if (mono_error_set_pending_exception (&error)) //returns TRUE if an exception was set
+    if (mono_error_set_pending_exception (error)) //returns TRUE if an exception was set
         return;
 
     //2nd option: legacy code that can't handle failures:
-    mono_error_assert_ok (&error);
+    mono_error_assert_ok (error);
 
     //3rd option (deprecated): raise an exception and write a FIXME note
     //  (implicit cleanup, no-op if there was no error)
-    mono_error_raise_exception (&error); /* FIXME don't raise here */
+    mono_error_raise_exception (error); /* FIXME don't raise here */
 
     //4th option: ignore
-    mono_error_cleanup (&error);
+    mono_error_cleanup (error);
 }
 ```
 
 Important points from the above:
 
-- Add a "MonoError error" variable to the required argument
+- Use `ERROR_DECL (error)` to declare and initialize a `MonoError *error` variable.
+   (Under the hood, it declares a local `MonoError error_value` using `ERROR_DECL_VALUE (error_value)`.
+    You may use `ERROR_DECL_VALUE (e)` to declare a variable local variable yourself.  It's pretty unusual to need to do that,     however.)
 - Pass it to the required function and always do something with the result
 - Given we're still transitioning, not all code can handle in the same ways
-- Since all calls that take a MonoError init it, only check it after the first call;
 
 Handling the transition
 =======================
@@ -106,6 +105,64 @@ assert on failure or cleanup the error as there's no adequate alternative at thi
 
 - When possible, change the function signature. If not, add a _checked variant and add the `MONO_RT_EXTERNAL_ONLY` to
 the non-checked version if it's in the Mono API.  That symbol will prevent the rest of the Mono runtime from calling the non-checked version.
+
+Advanced technique: using a local error to raise a different exception
+======================================================================
+
+Suppose you want to call a function `foo_checked()` but you want to raise a different exception if it fails.
+In this case, it makes sense to create a local error variable to handle the call to `foo_checked`:
+
+```c
+int
+my_function (MonoObject *arg, MonoError *error)
+{
+    ERROR_DECL (local_error);
+    int result = foo_checked (arg, local_error);
+    if (!is_ok (local_error)) {
+        mono_error_set_execution_engine (error, "Could not successfully call foo_checked, due to: %s", mono_error_get_message (local_error));
+        mono_error_cleanup (local_error);
+    }
+    return result;
+```
+
+- Pass `local_error` to `foo_checked`
+- Check the result and if it wasn't okay, set a different error code on `error`
+   It is common to use `mono_error_get_message` to include the message from the local failure as part of the new exception
+- Cleanup `local_error` to release its resources
+
+Advanced technique: MonoErrorBoxed and mono_class_set_failure
+=============================================================
+
+Normally we store a `MonoError` on the stack.  The usual scenario is that managed code calls into the runtime,
+we perform some operations, and then we either return a result or convert a `MonoError` into a pending exception.
+So a stack lifetime for a `MonoError` makes sense.
+
+There is one scenario where we need a heap-allocated `MonoError` whose lifetime is tied to a `MonoImage`: the initialization of a managed class.  `MonoErrorBoxed` is a thin wrapper around a `MonoError` that identifies a `MonoError` that is allocated
+in the mempool of a `MonoImage`.  It is created using `mono_error_box()` and converted back to an ordinary `MonoError` using
+`mono_error_unbox()`.
+
+```c
+static int
+some_class_init_helper (MonoClass *k)
+{
+    if (mono_class_has_failure (k))
+        return -1; /* Already a failure, don't bother trying to init it */
+    ERROR_DECL (local_error);
+    int result = foo_checked (k, local_error);
+    if (!is_ok (error)) {
+      mono_class_set_failure (k, mono_error_box (local_error, k->image));
+      mono_error_cleanup (local_error);
+    }
+    return result;
+}
+```
+
+- Check whether the class is already marked as a failure
+- Pass a `local_error` to `foo_checked`
+- Check the result and if it wasn't okay, allocate a boxed `MonoError` in the mempool of
+  the class's image
+- Mark the class that failed with the boxed error
+- Cleanup the `local_error` to release its resources
 
 ## Design issues
 


### PR DESCRIPTION
- Describe ERROR_DECL and the new initialization semantics
- Add some examples of advanced usage (local errors and marking a class as a failure).