### PR TITLE
Fix the docs page validation for release 5.12.0

### DIFF
--- a/docs/about-mono/releases/5.12.0.md
+++ b/docs/about-mono/releases/5.12.0.md
@@ -15,7 +15,7 @@ Highlights
 
 * [Port to IBM AIX/i](#IBM-AIX-and-IBM-i)
 * [Interpreter enhancements](#interpreter)
-* [New VB.NET compiler](#vb.net-compiler)
+* [New VB.NET compiler](#vbnet-compiler)
 
 # In Depth
 


### PR DESCRIPTION
When clicking the `#` button next to the vb.net compiler section, the link generated is: http://www.mono-project.com/docs/about-mono/releases/5.12.0/#vbnet-compiler
This updates the link in the markdown to use the correct version that doesn't fall validation