### PR TITLE
Small typo: Correct compiler name in mono-basics.md

### DIFF
--- a/docs/getting-started/mono-basics.md
+++ b/docs/getting-started/mono-basics.md
@@ -23,7 +23,7 @@ public class HelloWorld
 }
 ```
 
-To compile, use mcs:
+To compile, use csc:
 
     csc hello.cs
 


### PR DESCRIPTION
**Note:** There remains one other mention of `mcs` in the section [Gtk# Hello World](http://www.mono-project.com/docs/getting-started/mono-basics/#gtk-hello-world) of the same document:

> To compile, use mcs with the -pkg option to tell the compiler to pull in the Gtk# libraries (note that Gtk# must be installed on your system for this to work):
>
> ```
> mcs hello.cs -pkg:gtk-sharp-2.0
> ```

I cannot test this on my system, so I left it as is. Should it be `csc` here as well?