### PR TITLE
[runtime debugging] note for SIGSEGV with LLDB

### DIFF
--- a/docs/debug+profile/debug/index.md
+++ b/docs/debug+profile/debug/index.md
@@ -162,6 +162,13 @@ Assuming the above script is saved in `~/Library/lldb/monobt.py`, you can load i
 
 Once the script is loaded, you can type `monobt` to get a backtrace of the currently selected thread with managed frames symbolicated.
 
+### Known limitiations
+
+If a segmentation fault occurs (`EXC_BAD_ACCESS`) [LLDB can't resume to the signal handler](https://bugs.llvm.org/show_bug.cgi?id=22868#c1). Unfortunately this conflicts with implicit null checks used by Mono. Workarounds until this is fixed:
+1. Run mono with `MONO_DEBUG=explicit-null-checks`, so the runtime won't use mentioned technique. Performance-wise this is a bit slower, but for debugging purposes that's fine.
+2. Use `gdb`. Unfortunately this requires some work on macOS these days.
+
+
 Debugging With Visual Studio on Windows
 ---------------------------------------
 


### PR DESCRIPTION
also see https://github.com/mono/mono/issues/10180