### PR TITLE
Update macos.md to raise version requirement

### DIFF
--- a/_includes/download.html
+++ b/_includes/download.html
@@ -71,7 +71,7 @@
           {% endif %}
           <a href="{{mono_mac_url}}" class="button radius"><i class="fas fa-download"></i> Download Mono</a>
           {% endif %}
-          <p>Supported on macOS 10.7 and later. Check the <a href="/docs/about-mono/supported-platforms/macos/#uninstalling-mono-on-macos">uninstall instructions</a> if you want to remove Mono from your Mac.</p>
+          <p>Supported on macOS 10.9 and later. Check the <a href="/docs/about-mono/supported-platforms/macos/#uninstalling-mono-on-macos">uninstall instructions</a> if you want to remove Mono from your Mac.</p>
         </div>
         {% if include.releasename == "Stable" %}
         <p><i>* We recommend this package if you're using Visual Studio for Mac since the stability of Visual Studio for Mac is only guaranteed with the Visual Studio channel releases.</i></p>

--- a/docs/about-mono/supported-platforms/macos.md
+++ b/docs/about-mono/supported-platforms/macos.md
@@ -9,7 +9,7 @@ redirect_from:
 Introduction to Mono on macOS
 -----------------------------
 
-Mono supports macOS version 10.7 (Lion) and later.
+Mono supports macOS version 10.9 (Mavericks) and later.
 
 You can use Mono on macOS to build server, console and GUI applications. Read below for the options available for GUI application development.
 
@@ -35,7 +35,7 @@ The Mono package includes:
 
 This package installs as a framework to /Library/Framework (the same way the Java packages are installed). Symlinks are created for the executables in /usr/bin. If you'd like to access the mono *manpages* you'll have to add /Library/Frameworks/Mono.framework/Versions/Current/man to your *manpath*. The macOS Mono package does not include [Gtk#](/GtkSharp), XSP or mod_mono. These will have to be compiled from source.
 
-Our packages currently require Mono macOS 10.7 or better, for older versions, you will need to build from source code.
+Our packages currently require Mono macOS 10.9 or better, for older versions, you will need to build from source code.
 
 Using Mono on macOS
 -------------------

--- a/docs/about-mono/supported-platforms/macos.md
+++ b/docs/about-mono/supported-platforms/macos.md
@@ -35,7 +35,7 @@ The Mono package includes:
 
 This package installs as a framework to /Library/Framework (the same way the Java packages are installed). Symlinks are created for the executables in /usr/bin. If you'd like to access the mono *manpages* you'll have to add /Library/Frameworks/Mono.framework/Versions/Current/man to your *manpath*. The macOS Mono package does not include [Gtk#](/GtkSharp), XSP or mod_mono. These will have to be compiled from source.
 
-Our packages currently require Mono macOS 10.9 or better, for older versions, you will need to build from source code.
+Our packages currently require macOS 10.9 or better, for older versions, you will need to build from source code.
 
 Using Mono on macOS
 -------------------


### PR DESCRIPTION
Raise listed version requirement to 10.9. I'm not clear on what 'our packages currently require mono macos 10.7 or better' means, and whether i should update that to 10.9 as well? Shouldn't that be a *mono* version number?

https://github.com/mono/mono/issues/9581