### PR TITLE
small typo when trying to compile mono in terminal

### DIFF
--- a/docs/getting-started/mono-basics.md
+++ b/docs/getting-started/mono-basics.md
@@ -23,9 +23,9 @@ public class HelloWorld
 }
 ```
 
-To compile, use csc:
+To compile, use msc:
 
-    csc hello.cs
+    msc hello.cs
 
 The compiler will create "hello.exe", which you can run using:
 


### PR DESCRIPTION
had trouble when trying to follow the documentation directions.  running "csc hello.cs" returns the following: 
` csc hello.cs

Command 'csc' not found, but can be installed with:

sudo apt install chicken-bin`

However when I ran the "msc hello.cs" it created the executable. This on a linux machine: debian distro