### PR TITLE
Corrected reference to tlstest (mono-basics.md) which is not working in master

### DIFF
--- a/docs/getting-started/mono-basics.md
+++ b/docs/getting-started/mono-basics.md
@@ -40,10 +40,10 @@ Hello Mono World
 HTTPS connections
 -----------------
 
-To make sure HTTPS connections work, download and run the [tlstest](https://raw.github.com/mono/mono/master/mcs/class/Mono.Security/Test/tools/tlstest/tlstest.cs) tool (needs Mono >= 3.4.0).
+To make sure HTTPS connections work, download and run the [tlstest](https://raw.githubusercontent.com/mono/mono/86c3c50c8d21c544f4cb1b10bb32d4aa0f9d0d8d/mcs/class/Mono.Security/Test/tools/tlstest/tlstest.cs) tool (needs Mono >= 3.4.0).
 
 ``` bash
-csc tlstest.cs -r:System.dll
+csc tlstest.cs -r:System.dll -r:Mono.Security.dll
 mono tlstest.exe https://www.nuget.org
 ```
 

--- a/docs/getting-started/mono-basics.md
+++ b/docs/getting-started/mono-basics.md
@@ -40,7 +40,7 @@ Hello Mono World
 HTTPS connections
 -----------------
 
-To make sure HTTPS connections work, download and run the [tlstest](https://raw.githubusercontent.com/mono/mono/86c3c50c8d21c544f4cb1b10bb32d4aa0f9d0d8d/mcs/class/Mono.Security/Test/tools/tlstest/tlstest.cs) tool (needs Mono >= 3.4.0).
+To make sure HTTPS connections work, download and run the [tlstest](https://raw.githubusercontent.com/mono/mono/2aeb4afa26c4c5f578a3e46643b22f6bfe106a00/mcs/class/Mono.Security/Test/tools/tlstest/tlstest.cs) tool (needs Mono >= 3.4.0).
 
 ``` bash
 csc tlstest.cs -r:System.dll -r:Mono.Security.dll


### PR DESCRIPTION
Since tlstest was removed in master, I replaced the link to tlstest with an older branch.
I have also corrected the command to compile it, because it needs a reference to Mono.Security.dll otherwise we get this error: 
tlstest.cs(23,21): error CS0234: The type or namespace name 'Protocol' does not exist in the namespace 'Mono.Security'. Are you missing an assembly reference?