### PR TITLE
cla2.dotnetfoundation.org -> cla.dotnetfoundation.org

### DIFF
--- a/community/contributing/index.md
+++ b/community/contributing/index.md
@@ -70,7 +70,7 @@ Contributing to Mono
 Mono now part of the .NET Foundation
 ------------------------------------
 
-The Mono project is now part of the .NET Foundation and contributors have to sign the [.NET Foundation CLA](https://cla2.dotnetfoundation.org) before submitting a pull request.
+The Mono project is now part of the .NET Foundation and contributors have to sign the [.NET Foundation CLA](https://cla.dotnetfoundation.org) before submitting a pull request.
 
 Contributing to the Class Libraries
 -----------------------------------

--- a/docs/faq/general.md
+++ b/docs/faq/general.md
@@ -103,7 +103,7 @@ Please see the [Mono Roadmap](/docs/about-mono/roadmap/) for more details on the
 
 ### How can I contribute?
 
-Check the [contributing](/community/contributing/) section. You will also have to sign the [.NET Foundation CLA](https://cla2.dotnetfoundation.org).
+Check the [contributing](/community/contributing/) section. You will also have to sign the [.NET Foundation CLA](https://cla.dotnetfoundation.org).
 
 ### Aren't you just copying someone else's work?
 

--- a/docs/faq/licensing.md
+++ b/docs/faq/licensing.md
@@ -24,7 +24,7 @@ Note that as of March 31st, 2016 the Mono runtime and tools have been relicensed
 
 ### I would like to contribute code to Mono under a particular license. What licenses will you accept?
 
-Contributions are now taken under the [.NET Foundation CLA](https://cla2.dotnetfoundation.org).
+Contributions are now taken under the [.NET Foundation CLA](https://cla.dotnetfoundation.org).
 
 Patents
 -------


### PR DESCRIPTION
I can't see https://cla2.dotnetfoundation.org anymore - but https://cla.dotnetfoundation.org works.  That's the one we want, right?