### PR TITLE
Add curl for sdks webassembly.

### DIFF
--- a/docs/compiling-mono/linux/index.md
+++ b/docs/compiling-mono/linux/index.md
@@ -40,7 +40,7 @@ On Debian based distribution you should guarantee that some packages are install
 This can be done easily by using *apt-get*:
 
 ```bash
-  $ sudo apt-get install git autoconf libtool automake build-essential gettext cmake python
+  $ sudo apt-get install git autoconf libtool automake build-essential gettext cmake python curl
 ```
 
 Note: if you are using Ubuntu 15.04/Debian 8 or later, you also need to install the `libtool-bin` package. Without it, you will get the following error: `**Error**: You must have 'libtool' installed to compile Mono.`


### PR DESCRIPTION
Maybe this is too esoteric, and obvious, but I tried running the WebAssembly CI.

/usr/bin/make /mnt/c/s/mono2/sdks/out/llvm-llvmwin32/.stamp-download
make[1]: Entering directory '/mnt/c/s/mono2/sdks/builds'
llvm.mk:40: target '/mnt/c/s/mono2/sdks/out/llvm-llvmwin32/.stamp-download' does not exist
curl --location --silent --show-error "http://xamjenkinsartifact.blob.core.windows.net/mono-sdks/llvm-llvmwin32-64c0343537016c153894dc60316bd7b316b812c8-Linux.tar.gz" | tar -xvzf - -C /mnt/c/s/mono2/sdks/out/llvm-llvmwin32/
/bin/bash: curl: command not found