### PR TITLE
page mono-basics, change compiler csc to msc 

### DIFF
--- a/docs/getting-started/mono-basics.md
+++ b/docs/getting-started/mono-basics.md
@@ -24,9 +24,9 @@ public class HelloWorld
 }
 ```
 
-To compile, use [msc](/docs/about-mono/languages/csharp/):
+To compile, use [mcs](/docs/about-mono/languages/csharp/):
 
-    msc hello.cs
+    mcs hello.cs
 
 The compiler will create "hello.exe", which you can run using:
 

--- a/docs/getting-started/mono-basics.md
+++ b/docs/getting-started/mono-basics.md
@@ -24,9 +24,9 @@ public class HelloWorld
 }
 ```
 
-To compile, use csc:
+To compile, use [msc](/docs/about-mono/languages/csharp/):
 
-    csc hello.cs
+    msc hello.cs
 
 The compiler will create "hello.exe", which you can run using:
 


### PR DESCRIPTION
In the Hello World example of the [Mono Basics](https://www.mono-project.com/docs/getting-started/mono-basics/) page, the csc compiler is used to compile the example.

This pull request suggests that instead of the csc compiler, the mcs compiler should be used, together with a link to the msc description page https://www.mono-project.com/docs/about-mono/languages/csharp/

### Background

I installed `mono-complete` on a machine running Ubuntu, and tried to follow the Hello World example to verify if everything was installed fine. However `csc` was not installed, so the instructions didn't work. Took me a few minutes to get to know that it should be `mcs` instead.