### PR TITLE
fix: List of supported AOT platforms

### DIFF
--- a/docs/advanced/aot.md
+++ b/docs/advanced/aot.md
@@ -74,7 +74,7 @@ This testing is required because some of Mono's class libraries generate code dy
 
 #### Limitation: Platform
 
-Full AOT currently only works on AMD64/ARM.
+Full AOT currently only works on X86/AMD64/ARM.
 
 #### Generic ValueType Sharing
 


### PR DESCRIPTION
The `limitation: Platform` list is out of sync with the section below `Supported Platforms`

Perhaps it would be worth removing this section altogether? Since it's again listed a few lines below?