### PR TITLE
Recommend installing Python 3 on Linux

### DIFF
--- a/docs/compiling-mono/linux/index.md
+++ b/docs/compiling-mono/linux/index.md
@@ -40,7 +40,7 @@ On Debian based distribution you should guarantee that some packages are install
 This can be done easily by using *apt-get*:
 
 ```bash
-  $ sudo apt-get install git autoconf libtool automake build-essential gettext cmake python curl
+  $ sudo apt-get install git autoconf libtool automake build-essential gettext cmake python3 curl
 ```
 
 Note: if you are using Ubuntu 15.04/Debian 8 or later, you also need to install the `libtool-bin` package. Without it, you will get the following error: `**Error**: You must have 'libtool' installed to compile Mono.`


### PR DESCRIPTION
We require it all over now, and this should correspond with an update to configure.ac to ensure we require Python 3. We already recommend installing it on MacOS, so this just makes our docs consistent.