### PR TITLE
Clean up x86 page

### DIFF
--- a/docs/about-mono/supported-platforms/x86.md
+++ b/docs/about-mono/supported-platforms/x86.md
@@ -1,23 +1,20 @@
 ---
-title: X86
+title: x86
 redirect_from:
   - /Mono%3AX86/
 ---
+Mono is most tuned for execution on x86 machines. Supported platforms:
 
-Mono's main developers use x86 systems and its the most tuned version, currently it supports:
-
--   Linux.
--   Windows.
--   BSD (Requires a modern version for proper thread support).
+-   Linux
+-   Windows
+-   BSD*
 -   Solaris/x86
 
-Mono on x86 supports both Just-in-Time (JIT) compilation as well as Ahead-of-Time ([AOT](/docs/advanced/aot/)) compilation, the later produces Position Independent Code.
+*Requires a modern version for proper thread support
 
-X86 Specific Optimizations
+Mono on x86 supports both Just-in-Time (JIT) and Ahead-of-Time ([AOT](/docs/advanced/aot/)) compilation, the latter producing Position Independent Code (PIC).
+
+x86 Specific Optimizations
 ==========================
 
--   Thread local storage (TLS): on systems that support TLS, Mono is able to take advantage of it.
--   x86 peephole optimizations.
--   Instruction selector is able to pick best instructions on x86.
-
-
+Mono is able to take advantage of Thread Local Storage (TLS) on systems that support it. It can also apply peephole optimizations to generated instructions.


### PR DESCRIPTION
I've made a few formatting changes, but I've also removed the statement "Instruction selector is able to pick best instructions on x86". I don't think it makes sense as an "optimization" given that it should be a given that the compiler chooses instructions from the correct instruction set. I could have misinterpreted that though, so I'm happy to add it back if need be.