### PR TITLE
Fixed grammar and links

### DIFF
--- a/docs/about-mono/languages/index.md
+++ b/docs/about-mono/languages/index.md
@@ -21,7 +21,7 @@ C# is specified in the ISO/IEC 23271:2006 and ECMA 334 standards. Microsoft has 
 F#
 ---
 
-[F#](http://fsharp.org/) is a hybrid language that brings flavors of functional languages and imperative languages, developed by Microsoft. They release compiler that targets mono in [some releases](http://blogs.msdn.com/b/dsyme/archive/2010/04/12/f-2-0-released-as-part-of-visual-studio-2010.aspx).
+[F#](http://fsharp.org/) is a hybrid language that brings flavors of functional languages and imperative languages, developed by Microsoft. They release compiler that targets Mono in [some releases](http://blogs.msdn.com/b/dsyme/archive/2010/04/12/f-2-0-released-as-part-of-visual-studio-2010.aspx).
 
 Java
 ----
@@ -31,7 +31,7 @@ Java applications can run in Mono, see the [Java](/docs/about-mono/languages/jav
 Scala
 -----
 
-Scala is a modern language primarily targeting Java, and it's ported to .NET as [Scala.NET](http://www.scala-lang.org/node/168), which is also [known to run on mono](http://davidsiegel.org/scala-on-mono/).
+Scala is a modern language primarily targeting Java, and it's ported to .NET as [Scala.NET](http://www.scala-lang.org/node/168), which is also known to run on Mono.
 
 Boo
 ---
@@ -41,7 +41,7 @@ Boo
 Nemerle
 -------
 
-Nemerle is a new hybrid (functional, object-oriented and imperative) programming language for the .NET platform. It is available from [www.nemerle.org](http://www.nemerle.org).
+[Nemerle](http://www.nemerle.org) is a new hybrid (functional, object-oriented and imperative) programming language for the .NET platform.
 
 Visual Basic.NET
 ----------------
@@ -60,9 +60,9 @@ There are two possible choices here: PythonNet and IronPython.
 JavaScript
 ----------
 
-[IronJS](https://github.com/fholm/IronJS) is a DLR-based Javascript implementation that targets mono as well as .NET.
+[IronJS](https://github.com/fholm/IronJS) is a DLR-based Javascript implementation that targets Mono as well as .NET.
 
-Historically mono used to ship 'mjs', an implementation of the JavaScript language as part of its distribution, the main author behind this effort is César Natarén.
+Historically Mono used to ship 'mjs', an implementation of the JavaScript language as part of its distribution, the main author behind this effort is César Natarén.
 
 For more details see [JScript](/archived/jscript)
 
@@ -145,7 +145,7 @@ The compiler can be used to statically compile a Ruby source file into a verifia
 ADA
 ---
 
-A# is an ADA compiler for the CIL platform, it can be downloaded from: [here](http://asharp.martincarlisle.com/)
+A# is an ADA compiler for the CIL platform, it can be downloaded from: [here](http://asharp.martincarlisle.com/).
 
 Other PHP Efforts
 -----------------
@@ -164,7 +164,7 @@ Languages which are believed to work, but have not had a complete run of all the
 Tachy
 -----
 
-A subset of Scheme language called [Tachy](https://github.com/jeffdik/tachy/tree/master/src)
+A subset of Scheme language called [Tachy](https://github.com/jeffdik/tachy/tree/master/src).
 
 Mixing with other languages
 ---------------------------
@@ -176,4 +176,4 @@ See [Mixing with other languages](/docs/about-mono/languages/mixing-with-other-l
 
 [Brian Ritchie](https://bitbucket.org/brianritchie/wiki/wiki/.NET%20Languages) have a list of a lot of .NET languages.
 
-[Language Comparison](http://bean.wikidot.com/comparecsharpironpythonboo) - A simple comparison of some languages can be used with the Mono platform
+[Language Comparison](http://bean.wikidot.com/comparecsharpironpythonboo) - A simple comparison of some languages can be used with the Mono platform.

--- a/docs/about-mono/showcase/screenshots.md
+++ b/docs/about-mono/showcase/screenshots.md
@@ -52,7 +52,7 @@ Gtk# Applications
       <td><a class="image-link" title="OpenVPN-Admin" href="/archived/images/3/37/Openvpn-admin.png"><img alt="OpenVPN-Admin" src="/archived/images/3/37/Openvpn-admin.png" width="180" /></a></td>
     </tr>
     <tr>
-      <td><a href="http://pinta-project.com/">Pinta</a> <br /> Pinta is a paint program designed for simplicity and ease of use. It is modeled after <a href="http://getpaint.net/">Paint.Net</a>.</td>
+      <td><a href="http://pinta-project.com/">Pinta</a> <br /> Pinta is a paint program designed for simplicity and ease of use. It is modeled after <a href="http://getpaint.net/">Paint.NET</a>.</td>
       <td><a class="image-link" title="Pinta" href="/archived/images/5/59/Pinta1.jpg"><img alt="Pinta" src="/archived/images/5/59/Pinta1.jpg" width="180" /></a></td>
       <td><a class="image-link" title="Pinta" href="/archived/images/d/d8/Pinta2.jpg"><img alt="Pinta" src="/archived/images/d/d8/Pinta2.jpg" width="180" /></a></td>
     </tr>
@@ -77,7 +77,7 @@ Winforms Applications
 <table>
   <tbody>
     <tr>
-      <td><a href="http://nclass.sourceforge.net/">NClass</a> <br /> NClass is a UML modeling application written in C#. <br /><br /> <a href="http://www.getpaint.net/">Paint.NET</a> <br /> Paint.Net hasn't been fully ported to Mono yet (due to p/invokes), but we can still see it using the new 2.0 controls.</td>
+      <td><a href="http://nclass.sourceforge.net/">NClass</a> <br /> NClass is a UML modeling application written in C#. <br /><br /> <a href="http://www.getpaint.net/">Paint.NET</a> <br /> Paint.NET hasn't been fully ported to Mono yet (due to p/invokes), but we can still see it using the new 2.0 controls.</td>
       <td><a class="image-link" title="NClass" href="/archived/images/a/aa/Nclass.png"><img alt="NClass" src="/archived/images/a/aa/Nclass.png" width="180" /></a></td>
       <td><a class="image-link" title="Paint.NET" href="/archived/images/b/b9/Monopaint.png"><img alt="Paint.NET" src="/archived/images/b/b9/Monopaint.png" width="180" /></a></td>
     </tr>
@@ -97,7 +97,7 @@ Winforms Applications
       <td><a class="image-link" title="NUnit" href="/archived/images/3/35/Nunit2.png"><img alt="NUnit" src="/archived/images/3/35/Nunit2.png" width="180" /></a></td>
     </tr>
     <tr>
-      <td><a href="/MoMA">MoMA</a> <br /> MoMA is a tool that helps you identify issues you may have when porting your .Net application to Mono.</td>
+      <td><a href="/MoMA">MoMA</a> <br /> MoMA is a tool that helps you identify issues you may have when porting your .NET application to Mono.</td>
       <td><a class="image-link" title="MoMA" href="/archived/images/8/89/Linmoma1.png"><img alt="MoMA" src="/archived/images/8/89/Linmoma1.png" width="180" /></a></td>
       <td><a class="image-link" title="MoMA" href="/archived/images/c/c6/Linmoma2.png"><img alt="MoMA" src="/archived/images/c/c6/Linmoma2.png" width="180" /></a></td>
     </tr>
@@ -167,7 +167,7 @@ Other Mono Applications
       <td><a class="image-link" title="Maemo" href="/archived/images/b/bd/Nokia.jpg"><img alt="Maemo" src="/archived/images/b/bd/Nokia.jpg" width="180" /></a></td>
     </tr>
     <tr>
-      <td><a href="http://www.eclipse.org/">Eclipse</a> <br /> Eclipse is an IDE written in Java. It can run on Mono using <a href="http://www.ikvm.net/">IKVM</a>, the Java VM for .Net.</td>
+      <td><a href="http://www.eclipse.org/">Eclipse</a> <br /> Eclipse is an IDE written in Java. It can run on Mono using <a href="http://www.ikvm.net/">IKVM</a>, the Java VM for .NET.</td>
       <td>Eclipse on IKVM</td>
     </tr>
     <tr>

--- a/docs/about-mono/supported-platforms/linux.md
+++ b/docs/about-mono/supported-platforms/linux.md
@@ -6,7 +6,7 @@ redirect_from:
 
 Mono is primarily developed on Linux, and most of its users are Linux users, so it is the platform best supported.
 
-Packages for various distributions are available on our [Downloads](/download/stable/) page.
+Packages for various distributions are available on our [Downloads](/download/stable/#download-lin) page.
 
 Mono on Linux supports a number of Linux-specific optimizations.
 

--- a/docs/getting-started/install/mac/index.md
+++ b/docs/getting-started/install/mac/index.md
@@ -6,7 +6,7 @@ Mono runs on Mac, this page describes the various features available for users w
 
 Installing Mono on macOS is very simple:
 
-1.  [Download](/download/stable/) the latest Mono release for Mac
+1.  [Download](/download/stable/#download-mac) the latest Mono release for Mac
 2.  Run the .pkg file and accept the terms of the license. Mono is now installing:
 
     [![mono-mac-install.png](/images/mono-mac-install.png)](/images/mono-mac-install.png)


### PR DESCRIPTION
Fixed grammar by adding periods, changing .Net to .NET, and mono to Mono.
Removed a broken link (lead to gambling website)
Updated links to lead to correct download tab (ex: Mac now leads to Mac download)