### PR TITLE
Migrate apt scripts to use Signed-By feature

### DIFF
--- a/_includes/download.html
+++ b/_includes/download.html
@@ -94,42 +94,42 @@
             <p>The package repository hosts the packages you need, add it with the following commands.</p>
             <p><i>Note:</i> the packages should work on newer Ubuntu versions too but we only test the ones listed below.</p>
             <h3>Ubuntu 20.04 <small>(amd64, armhf, arm64, ppc64el)</small></h3>
-{% if include.releasename == "Nightly" %}
-<pre><code class="language-bash">sudo apt install gnupg ca-certificates
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-echo "deb https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
-echo "deb https://download.mono-project.com/repo/ubuntu preview-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
+            {% if include.releasename == "Nightly" %}
+<pre><code class="language-bash">sudo apt install apt-transport-https ca-certificates gnupg
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu preview-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
-<pre><code class="language-bash">sudo apt install gnupg ca-certificates
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-echo "deb https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
+<pre><code class="language-bash">sudo apt install apt-transport-https ca-certificates gnupg
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
 {% endif %}
             <h3>Ubuntu 18.04 <small>(i386, amd64, armhf, arm64, ppc64el)</small></h3>
 {% if include.releasename == "Nightly" %}
-<pre><code class="language-bash">sudo apt install gnupg ca-certificates
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-echo "deb https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
-echo "deb https://download.mono-project.com/repo/ubuntu preview-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
+<pre><code class="language-bash">sudo apt install apt-transport-https ca-certificates gnupg
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu preview-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
-<pre><code class="language-bash">sudo apt install gnupg ca-certificates
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-echo "deb https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
+<pre><code class="language-bash">sudo apt install apt-transport-https ca-certificates gnupg
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
 {% endif %}
             <h3>Ubuntu 16.04 <small>(i386, amd64, armhf, arm64, ppc64el)</small></h3>
 {% if include.releasename == "Nightly" %}
-<pre><code class="language-bash">sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-sudo apt install apt-transport-https ca-certificates
-echo "deb https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
-echo "deb https://download.mono-project.com/repo/ubuntu preview-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
+<pre><code class="language-bash">sudo apt install apt-transport-https ca-certificates gnupg
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu preview-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
-<pre><code class="language-bash">sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-sudo apt install apt-transport-https ca-certificates
-echo "deb https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
+<pre><code class="language-bash">sudo apt install apt-transport-https ca-certificates gnupg
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
 {% endif %}
             <hr />
@@ -166,27 +166,27 @@ sudo apt update</code></pre>
             <h3>Debian 10 <small>(i386, amd64, armhf, arm64, armel, ppc64el)</small></h3>
 {% if include.releasename == "Nightly" %}
 <pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-echo "deb https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-buster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
-echo "deb https://download.mono-project.com/repo/debian preview-buster main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-buster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian preview-buster main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
 <pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-echo "deb https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-buster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-buster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
 {% endif %}
             <h3>Debian 9 <small>(i386, amd64, armhf, arm64, armel, ppc64el)</small></h3>
 {% if include.releasename == "Nightly" %}
 <pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-echo "deb https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-stretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
-echo "deb https://download.mono-project.com/repo/debian preview-stretch main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-stretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian preview-stretch main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
 <pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-echo "deb https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-stretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-stretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
 {% endif %}
             <hr />
@@ -223,27 +223,27 @@ sudo apt update</code></pre>
             <h3>Raspbian 10 <small>(armhf)</small></h3>
 {% if include.releasename == "Nightly" %}
 <pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-echo "deb https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianbuster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
-echo "deb https://download.mono-project.com/repo/debian preview-raspbianbuster main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianbuster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian preview-raspbianbuster main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
 <pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-echo "deb https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianbuster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianbuster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
 {% endif %}
             <h3>Raspbian 9 <small>(armhf)</small></h3>
 {% if include.releasename == "Nightly" %}
 <pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-echo "deb https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianstretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
-echo "deb https://download.mono-project.com/repo/debian preview-raspbianstretch main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianstretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian preview-raspbianstretch main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
 <pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-echo "deb https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianstretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianstretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
 {% endif %}
             <hr />

--- a/_includes/download.html
+++ b/_includes/download.html
@@ -96,46 +96,40 @@
             <h3>Ubuntu 20.04 <small>(amd64, armhf, arm64, ppc64el)</small></h3>
             {% if include.releasename == "Nightly" %}
 <pre><code class="language-bash">sudo apt install ca-certificates gnupg
-sudo mkdir -m 700 /root/.gnupg
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+sudo gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu preview-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
 <pre><code class="language-bash">sudo apt install ca-certificates gnupg
-sudo mkdir -m 700 /root/.gnupg
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+sudo gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
 {% endif %}
             <h3>Ubuntu 18.04 <small>(i386, amd64, armhf, arm64, ppc64el)</small></h3>
 {% if include.releasename == "Nightly" %}
 <pre><code class="language-bash">sudo apt install ca-certificates gnupg
-sudo mkdir -m 700 /root/.gnupg
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+sudo gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu preview-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
 <pre><code class="language-bash">sudo apt install ca-certificates gnupg
-sudo mkdir -m 700 /root/.gnupg
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+sudo gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
 {% endif %}
             <h3>Ubuntu 16.04 <small>(i386, amd64, armhf, arm64, ppc64el)</small></h3>
 {% if include.releasename == "Nightly" %}
-<pre><code class="language-bash">sudo apt install apt-transport-https ca-certificates gnupg
-sudo mkdir -m 700 /root/.gnupg
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
-echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu preview-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
+<pre><code class="language-bash">sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+sudo apt install apt-transport-https ca-certificates
+echo "deb https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
+echo "deb https://download.mono-project.com/repo/ubuntu preview-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
-<pre><code class="language-bash">sudo apt install apt-transport-https ca-certificates gnupg
-sudo mkdir -m 700 /root/.gnupg
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
+<pre><code class="language-bash">sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+sudo apt install apt-transport-https ca-certificates
+echo "deb https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
 {% endif %}
             <hr />
@@ -171,31 +165,27 @@ sudo apt update</code></pre>
             <p><i>Note:</i> the packages should work on newer Debian versions too but we only test the ones listed below.</p>
             <h3>Debian 10 <small>(i386, amd64, armhf, arm64, armel, ppc64el)</small></h3>
 {% if include.releasename == "Nightly" %}
-<pre><code class="language-bash">sudo apt install dirmngr gnupg ca-certificates
-sudo mkdir -m 700 /root/.gnupg
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+<pre><code class="language-bash">sudo apt install dirmngr ca-certificates gnupg
+sudo gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-buster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian preview-buster main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
-<pre><code class="language-bash">sudo apt install dirmngr gnupg ca-certificates
-sudo mkdir -m 700 /root/.gnupg
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+<pre><code class="language-bash">sudo apt install dirmngr ca-certificates gnupg
+sudo gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-buster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
 {% endif %}
             <h3>Debian 9 <small>(i386, amd64, armhf, arm64, armel, ppc64el)</small></h3>
 {% if include.releasename == "Nightly" %}
-<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
-sudo mkdir -m 700 /root/.gnupg
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr ca-certificates gnupg
+sudo gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-stretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian preview-stretch main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
-<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
-sudo mkdir -m 700 /root/.gnupg
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr ca-certificates gnupg
+sudo gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-stretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
 {% endif %}
@@ -232,31 +222,27 @@ sudo apt update</code></pre>
             <p><i>Note:</i> the packages should work on newer Raspbian versions too but we only test the ones listed below.</p>
             <h3>Raspbian 10 <small>(armhf)</small></h3>
 {% if include.releasename == "Nightly" %}
-<pre><code class="language-bash">sudo apt install dirmngr gnupg ca-certificates
-sudo mkdir -m 700 /root/.gnupg
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+<pre><code class="language-bash">sudo apt install dirmngr ca-certificates gnupg
+sudo gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianbuster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian preview-raspbianbuster main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
-<pre><code class="language-bash">sudo apt install dirmngr gnupg ca-certificates
-sudo mkdir -m 700 /root/.gnupg
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+<pre><code class="language-bash">sudo apt install dirmngr ca-certificates gnupg
+sudo gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianbuster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
 {% endif %}
             <h3>Raspbian 9 <small>(armhf)</small></h3>
 {% if include.releasename == "Nightly" %}
-<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
-sudo mkdir -m 700 /root/.gnupg
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr ca-certificates gnupg
+sudo gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianstretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian preview-raspbianstretch main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
-<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
-sudo mkdir -m 700 /root/.gnupg
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr ca-certificates gnupg
+sudo gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianstretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
 {% endif %}

--- a/_includes/download.html
+++ b/_includes/download.html
@@ -171,14 +171,14 @@ sudo apt update</code></pre>
             <p><i>Note:</i> the packages should work on newer Debian versions too but we only test the ones listed below.</p>
             <h3>Debian 10 <small>(i386, amd64, armhf, arm64, armel, ppc64el)</small></h3>
 {% if include.releasename == "Nightly" %}
-<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
+<pre><code class="language-bash">sudo apt install dirmngr gnupg ca-certificates
 sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-buster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian preview-buster main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
-<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
+<pre><code class="language-bash">sudo apt install dirmngr gnupg ca-certificates
 sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-buster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
@@ -186,14 +186,14 @@ sudo apt update</code></pre>
 {% endif %}
             <h3>Debian 9 <small>(i386, amd64, armhf, arm64, armel, ppc64el)</small></h3>
 {% if include.releasename == "Nightly" %}
-<pre><code class="language-bash">sudo apt install dirmngr gnupg ca-certificates
+<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
 sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-stretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian preview-stretch main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
-<pre><code class="language-bash">sudo apt install dirmngr gnupg ca-certificates
+<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
 sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-stretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
@@ -247,14 +247,14 @@ sudo apt update</code></pre>
 {% endif %}
             <h3>Raspbian 9 <small>(armhf)</small></h3>
 {% if include.releasename == "Nightly" %}
-<pre><code class="language-bash">sudo apt install dirmngr gnupg ca-certificates
+<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
 sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianstretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian preview-raspbianstretch main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
-<pre><code class="language-bash">sudo apt install dirmngr gnupg ca-certificates
+<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
 sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianstretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list

--- a/_includes/download.html
+++ b/_includes/download.html
@@ -94,7 +94,7 @@
             <p>The package repository hosts the packages you need, add it with the following commands.</p>
             <p><i>Note:</i> the packages should work on newer Ubuntu versions too but we only test the ones listed below.</p>
             <h3>Ubuntu 20.04 <small>(amd64, armhf, arm64, ppc64el)</small></h3>
-            {% if include.releasename == "Nightly" %}
+{% if include.releasename == "Nightly" %}
 <pre><code class="language-bash">sudo apt install ca-certificates gnupg
 sudo gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list

--- a/_includes/download.html
+++ b/_includes/download.html
@@ -95,14 +95,14 @@
             <p><i>Note:</i> the packages should work on newer Ubuntu versions too but we only test the ones listed below.</p>
             <h3>Ubuntu 20.04 <small>(amd64, armhf, arm64, ppc64el)</small></h3>
             {% if include.releasename == "Nightly" %}
-<pre><code class="language-bash">sudo apt install apt-transport-https ca-certificates gnupg
+<pre><code class="language-bash">sudo apt install ca-certificates gnupg
 sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu preview-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
-<pre><code class="language-bash">sudo apt install apt-transport-https ca-certificates gnupg
+<pre><code class="language-bash">sudo apt install ca-certificates gnupg
 sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
@@ -110,14 +110,14 @@ sudo apt update</code></pre>
 {% endif %}
             <h3>Ubuntu 18.04 <small>(i386, amd64, armhf, arm64, ppc64el)</small></h3>
 {% if include.releasename == "Nightly" %}
-<pre><code class="language-bash">sudo apt install apt-transport-https ca-certificates gnupg
+<pre><code class="language-bash">sudo apt install ca-certificates gnupg
 sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu preview-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
-<pre><code class="language-bash">sudo apt install apt-transport-https ca-certificates gnupg
+<pre><code class="language-bash">sudo apt install ca-certificates gnupg
 sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
@@ -186,14 +186,14 @@ sudo apt update</code></pre>
 {% endif %}
             <h3>Debian 9 <small>(i386, amd64, armhf, arm64, armel, ppc64el)</small></h3>
 {% if include.releasename == "Nightly" %}
-<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
+<pre><code class="language-bash">sudo apt install dirmngr gnupg ca-certificates
 sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-stretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian preview-stretch main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
-<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
+<pre><code class="language-bash">sudo apt install dirmngr gnupg ca-certificates
 sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-stretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
@@ -232,14 +232,14 @@ sudo apt update</code></pre>
             <p><i>Note:</i> the packages should work on newer Raspbian versions too but we only test the ones listed below.</p>
             <h3>Raspbian 10 <small>(armhf)</small></h3>
 {% if include.releasename == "Nightly" %}
-<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
+<pre><code class="language-bash">sudo apt install dirmngr gnupg ca-certificates
 sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianbuster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian preview-raspbianbuster main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
-<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
+<pre><code class="language-bash">sudo apt install dirmngr gnupg ca-certificates
 sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianbuster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
@@ -247,14 +247,14 @@ sudo apt update</code></pre>
 {% endif %}
             <h3>Raspbian 9 <small>(armhf)</small></h3>
 {% if include.releasename == "Nightly" %}
-<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
+<pre><code class="language-bash">sudo apt install dirmngr gnupg ca-certificates
 sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianstretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian preview-raspbianstretch main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
-<pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
+<pre><code class="language-bash">sudo apt install dirmngr gnupg ca-certificates
 sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianstretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list

--- a/_includes/download.html
+++ b/_includes/download.html
@@ -96,12 +96,14 @@
             <h3>Ubuntu 20.04 <small>(amd64, armhf, arm64, ppc64el)</small></h3>
             {% if include.releasename == "Nightly" %}
 <pre><code class="language-bash">sudo apt install apt-transport-https ca-certificates gnupg
+sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu preview-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
 <pre><code class="language-bash">sudo apt install apt-transport-https ca-certificates gnupg
+sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
@@ -109,12 +111,14 @@ sudo apt update</code></pre>
             <h3>Ubuntu 18.04 <small>(i386, amd64, armhf, arm64, ppc64el)</small></h3>
 {% if include.releasename == "Nightly" %}
 <pre><code class="language-bash">sudo apt install apt-transport-https ca-certificates gnupg
+sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu preview-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
 <pre><code class="language-bash">sudo apt install apt-transport-https ca-certificates gnupg
+sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
@@ -122,12 +126,14 @@ sudo apt update</code></pre>
             <h3>Ubuntu 16.04 <small>(i386, amd64, armhf, arm64, ppc64el)</small></h3>
 {% if include.releasename == "Nightly" %}
 <pre><code class="language-bash">sudo apt install apt-transport-https ca-certificates gnupg
+sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu preview-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
 <pre><code class="language-bash">sudo apt install apt-transport-https ca-certificates gnupg
+sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu {{ include.releasename | downcase }}-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
@@ -166,12 +172,14 @@ sudo apt update</code></pre>
             <h3>Debian 10 <small>(i386, amd64, armhf, arm64, armel, ppc64el)</small></h3>
 {% if include.releasename == "Nightly" %}
 <pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
+sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-buster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian preview-buster main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
 <pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
+sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-buster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
@@ -179,12 +187,14 @@ sudo apt update</code></pre>
             <h3>Debian 9 <small>(i386, amd64, armhf, arm64, armel, ppc64el)</small></h3>
 {% if include.releasename == "Nightly" %}
 <pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
+sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-stretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian preview-stretch main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
 <pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
+sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-stretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
@@ -223,12 +233,14 @@ sudo apt update</code></pre>
             <h3>Raspbian 10 <small>(armhf)</small></h3>
 {% if include.releasename == "Nightly" %}
 <pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
+sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianbuster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian preview-raspbianbuster main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
 <pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
+sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianbuster main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>
@@ -236,12 +248,14 @@ sudo apt update</code></pre>
             <h3>Raspbian 9 <small>(armhf)</small></h3>
 {% if include.releasename == "Nightly" %}
 <pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
+sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianstretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian preview-raspbianstretch main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
 sudo apt update</code></pre>
 {% else %}
 <pre><code class="language-bash">sudo apt install apt-transport-https dirmngr gnupg ca-certificates
+sudo mkdir -m 700 /root/.gnupg
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian {{ include.releasename | downcase }}-raspbianstretch main" | sudo tee /etc/apt/sources.list.d/mono-official-{{ include.releasename | downcase }}.list
 sudo apt update</code></pre>


### PR DESCRIPTION
Changes apt-key usages to saving a local keyring directly via gpg. No new dependencies are introduced. Updates all apt source list configurations (Ubuntu, Debian and Raspbian) to use the signed-by feature pointing to this local keyring.

Usage of apt-key will be deprecated as per the manual apt-key(8): "apt-key will last be available in Debian 11 and Ubuntu 22.04."

Usage of global trusted PGP keys is also deprecated as they are widely insecure: they are unconditionally trusted by APT on all other repositories configured on the system that don't have a signed-by option, even the official Debian / Ubuntu repositories. As a result, any unofficial APT repository which has its signing key added to /etc/apt/trusted.gpg or /etc/apt/trusted.gpg.d can replace any package on the system.

According to the Debian wiki, the more proper and secure way of adding third-party repositories is to use the Signed-By feature in the apt sources list configuration. This should point to a local keyring, usually defined in /usr/share/keyrings/, with a trailing 'archive-keyring' postfix.

See: https://wiki.debian.org/DebianRepository/UseThirdParty
See: https://michael-prokop.at/blog/2021/02/16/how-to-properly-use-3rd-party-debian-repository-signing-keys-with-apt/