### PR TITLE
fix: broken ECMA 335 link

### DIFF
--- a/archived/books.md
+++ b/archived/books.md
@@ -52,7 +52,7 @@ C#
 
 [A Programmer's Introduction to C# - Second Edition](http://www.amazon.com/exec/obidos/tg/detail/-/1893115623/qid=1086275793/sr=8-2/ref=sr_8_xs_ap_i2_xgl14/103-3987558-5955806?v=glance&s=books&n=507846): Eric Gunnerson
 
-[C# Language Specification](http://www.ecma-international.org/publications/standards/Ecma-334.htm). The ECMA standard contains a very good introduction to the language and goes in depth into it.
+[C# Language Specification](https://www.ecma-international.org/publications-and-standards/standards/ecma-334/). The ECMA standard contains a very good introduction to the language and goes in depth into it.
 
 .NET Framework
 --------------

--- a/archived/net_framework_architecture.md
+++ b/archived/net_framework_architecture.md
@@ -77,14 +77,14 @@ An assembly can also be composed of several files.
 Common Language Infrastructure
 ==============================
 
-More commonly known as the Common Language Runtime , this is implemented by the Mono executable. This runtime is used to execute the compiled .NET application. The common language infrastructure is defined by ECMA standard [ECMA-335](http://www.ecma-international.org/publications/standards/Ecma-335.htm) .
+More commonly known as the Common Language Runtime , this is implemented by the Mono executable. This runtime is used to execute the compiled .NET application. The common language infrastructure is defined by ECMA standard [ECMA-335](https://www.ecma-international.org/publications-and-standards/standards/ecma-335/) .
 
 To run your application, you must invoke the runtime with the relevant parameters.
 
 Common Language Specification
 =============================
 
-This is specified in [ECMA-335](http://www.ecma-international.org/publications/standards/Ecma-335.htm),chapter 6. It defines the interface to the CLI, such as conventions like the underlying types for Enum.
+This is specified in [ECMA-335](https://www.ecma-international.org/publications-and-standards/standards/ecma-335/),chapter 6. It defines the interface to the CLI, such as conventions like the underlying types for Enum.
 
 The Mono compiler generates an image that conforms to the CLS. This is the Common Intermediate Language . The Mono runtime takes this image and runs it.
 
@@ -98,9 +98,9 @@ Within a native .NET/Mono application, all code is *managed*; that is, it is gov
 Bibliography
 ============
 
-ECMA Standard [334](http://www.ecma-international.org/publications/standards/Ecma-334.htm) , the C# language specification.
+ECMA Standard [334](https://www.ecma-international.org/publications-and-standards/standards/ecma-334/) , the C# language specification.
 
-ECMA Standard [335](http://www.ecma-international.org/publications/standards/Ecma-335.htm) , the Common Language Infrastructure.
+ECMA Standard [335](https://www.ecma-international.org/publications-and-standards/standards/ecma-335/) , the Common Language Infrastructure.
 
 MSDN documentation for the .NET framework is [here.](http://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpguide/html/cpconinsidenetframework.asp)
 

--- a/docs/about-mono/index.md
+++ b/docs/about-mono/index.md
@@ -9,7 +9,7 @@ redirect_from:
   - /What_is_Mono%3F/
 ---
 
-Mono, the open source development platform based on the .NET Framework, allows developers to build cross-platform applications with improved developer productivity. Mono's .NET implementation is based on the ECMA standards for [C#](http://www.ecma-international.org/publications/standards/Ecma-334.htm) and the [Common Language Infrastructure](http://www.ecma-international.org/publications/standards/Ecma-335.htm).
+Mono, the open source development platform based on the .NET Framework, allows developers to build cross-platform applications with improved developer productivity. Mono's .NET implementation is based on the ECMA standards for [C#](https://www.ecma-international.org/publications-and-standards/standards/ecma-334/) and the [Common Language Infrastructure](https://www.ecma-international.org/publications-and-standards/standards/ecma-335/).
 
 Supported previously by Novell, [Xamarin](http://xamarin.com/) and now [Microsoft](http://www.microsoft.com) and the [.NET Foundation](http://www.dotnetfoundation.org/), the Mono project has an active and enthusiastic contributing community. Mono includes both developer tools and the infrastructure needed to run .NET client and server applications.
 

--- a/docs/about-mono/languages/csharp.md
+++ b/docs/about-mono/languages/csharp.md
@@ -114,7 +114,7 @@ Experimental features that are being brainstormed for future versions of C# when
 
 ### Specification
 
-The C# 2.0 specification is available on the [third edition of the ECMA 334 standard](http://www.ecma-international.org/publications/standards/Ecma-334.htm).
+The C# 2.0 specification is available on the [third edition of the ECMA 334 standard](https://www.ecma-international.org/publications-and-standards/standards/ecma-334/).
 
 An on-line and hyperlinked version of the C# 1.0 specification is available from [Jon Jagger's](http://www.jaggersoft.com) site [here](http://www.jaggersoft.com/csharp_standard/).
 

--- a/docs/about-mono/languages/ecma/ecma-335-publicdraft.md
+++ b/docs/about-mono/languages/ecma/ecma-335-publicdraft.md
@@ -13,7 +13,7 @@ Since the initial submission, various Ecma member companies and individual contr
 A differently formatted version of each of these documents is being produced for final publication as
 
 1.  ISO/IEC standards and TR (1st edition). To monitor the progress of the publications, please visit [http://www.iso.org/iso/catalogue_detail.htm?csnumber=42927](http://www.iso.org/iso/catalogue_detail.htm?csnumber=42927)
-2.  ECMA standards and TR (2nd edition). To monitor the progress of the publications, please visit [http://www.ecma-international.org/publications/standards/Ecma-335.htm](http://www.ecma-international.org/publications/standards/Ecma-335.htm)
+2.  ECMA standards and TR (2nd edition). To monitor the progress of the publications, please visit [https://www.ecma-international.org/publications-and-standards/standards/ecma-335/](https://www.ecma-international.org/publications-and-standards/standards/ecma-335/)
 
 Work on the 5th edition of Ecma-335 CLI standard began in mid-2009. The TC49-TG3 task group is working on extending both the virtual machine and class libraries of the CLI specification. In addition, improvements are being made to clarify existing elements of the specification. Many of these improvements are the result of feedback received from outside the task group, for which the task group is grateful.
 

--- a/docs/about-mono/languages/ecma/index.md
+++ b/docs/about-mono/languages/ecma/index.md
@@ -16,7 +16,7 @@ If you are interested in obtaining copies of the 2010 Draft for ECMA 335, visit 
 
 ## Latest Standards
 
-The following official Ecma documents are available for [C#](http://www.ecma-international.org/publications/standards/Ecma-334.htm) and the [CLI](http://www.ecma-international.org/publications/standards/Ecma-335.htm) ([TR-84](http://www.ecma-international.org/publications/techreports/E-TR-084.htm), [TR-89](http://www.ecma-international.org/publications/techreports/E-TR-089.htm)).
+The following official Ecma documents are available for [C#](https://www.ecma-international.org/publications-and-standards/standards/ecma-334/) and the [CLI](https://www.ecma-international.org/publications-and-standards/standards/ecma-335/) ([TR-84](http://www.ecma-international.org/publications/techreports/E-TR-084.htm), [TR-89](http://www.ecma-international.org/publications/techreports/E-TR-089.htm)).
 
 -   [Ecma-334](http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-334.pdf): C# Specification (pdf)
 -   [Ecma-335](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-335.pdf): CLI Specification – Virtual Machine (pdf)

--- a/docs/advanced/pinvoke/index.md
+++ b/docs/advanced/pinvoke/index.md
@@ -9,7 +9,7 @@ redirect_from:
 
 ## Introduction
 
-The [Common Language Infrastructure](http://www.ecma-international.org/publications/standards/ecma-335.htm) (CLI) is designed to make it "easy" to interoperate with existing code. In principle, all you need to do is create a [DllImport](http://docs.go-mono.com/index.aspx?link=T:System.Runtime.InteropServices.DllImportAttribute) function declaration for the existing code to invoke, and the runtime will handle the rest. For example:
+The [Common Language Infrastructure](https://www.ecma-international.org/publications-and-standards/standards/ecma-335/) (CLI) is designed to make it "easy" to interoperate with existing code. In principle, all you need to do is create a [DllImport](http://docs.go-mono.com/index.aspx?link=T:System.Runtime.InteropServices.DllImportAttribute) function declaration for the existing code to invoke, and the runtime will handle the rest. For example:
 
 ``` csharp
  [DllImport ("libc.so")]

--- a/docs/advanced/runtime/index.md
+++ b/docs/advanced/runtime/index.md
@@ -5,7 +5,7 @@ redirect_from:
   - /Mono_Runtime/
 ---
 
-The Mono runtime implements the [ECMA Common Language Infrastructure](http://www.ecma-international.org/publications/standards/Ecma-335.htm) (CLI). The Mono runtime implements this virtual machine.
+The Mono runtime implements the [ECMA Common Language Infrastructure](https://www.ecma-international.org/publications-and-standards/standards/ecma-335/) (CLI). The Mono runtime implements this virtual machine.
 
 If you are interested in the technical aspects of the Mono runtime check the [Runtime Documentation](/docs/advanced/runtime/docs/).
 

--- a/docs/faq/general.md
+++ b/docs/faq/general.md
@@ -73,9 +73,9 @@ The CLR and the Common Type System (CTS) enables applications and libraries to b
 
 You can find the information here:
 
-C# [http://www.ecma-international.org/publications/standards/Ecma-334.htm](http://www.ecma-international.org/publications/standards/Ecma-334.htm)
+C# [https://www.ecma-international.org/publications-and-standards/standards/ecma-334/](https://www.ecma-international.org/publications-and-standards/standards/ecma-334/)
 
-CLI [http://www.ecma-international.org/publications/standards/Ecma-335.htm](http://www.ecma-international.org/publications/standards/Ecma-335.htm)
+CLI [https://www.ecma-international.org/publications-and-standards/standards/ecma-335/](https://www.ecma-international.org/publications-and-standards/standards/ecma-335/)
 
 ### Will you implement the .NET Framework SDK class libraries?
 

--- a/docs/tools+libraries/tools/monodocer.md
+++ b/docs/tools+libraries/tools/monodocer.md
@@ -75,7 +75,7 @@ Members Added: 0, Members Deleted: 0
 Monodocer supports importing two different documentation formats:
 
 1.  Inline XML documentation extracted via 'csc /doc' or 'mcs /doc'.
-2.  ECMA documentation, found at the [ECMA-335 page](http://www.ecma-international.org/publications/standards/Ecma-335.htm) within the ECMA-335.zip file.
+2.  ECMA documentation, found at the [ECMA-335 page](https://www.ecma-international.org/publications-and-standards/standards/ecma-335/) within the ECMA-335.zip file.
 
 Inline documentation is imported with '-importslashdoc', while ECMA documentation is imported with '-importecmadoc'.
 


### PR DESCRIPTION
Common Language Infrastructure (CLI) ECMA 335 specification link is broken. Updated with latest active link.