### PR TITLE
Add .net 4.8 to the compatibility table

### DIFF
--- a/docs/about-mono/compatibility.md
+++ b/docs/about-mono/compatibility.md
@@ -13,6 +13,12 @@ Here is a slightly more detailed view, by .NET framework version:
 
 |<i class="fas fa-check"/>|Implemented|<i class="fas fa-exclamation-triangle"/>|Partially Implemented|<i class="fas fa-ban"/>|Not Implemented|
 
+.NET 4.8
+--------
+
+|<i class="fas fa-check"/>|.NET Framework 4.8 profile reference assemblies|
+|<i class="fas fa-ban"/>|.NET Framework 4.8.1|
+
 .NET 4.7
 --------
 


### PR DESCRIPTION
Since mono 6.6.0 it supports .net 4.8 (but not 4.8.1). 
https://www.mono-project.com/docs/about-mono/releases/6.6.0/#net-48-reference-assemblies

And probably newer versions of C# too.